### PR TITLE
[migration] Add unique index to categories on name.

### DIFF
--- a/db/migrate/20160321021009_add_index_to_categories_name.rb
+++ b/db/migrate/20160321021009_add_index_to_categories_name.rb
@@ -1,0 +1,5 @@
+class AddIndexToCategoriesName < ActiveRecord::Migration
+  def change
+    add_index :categories, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160320200142) do
+ActiveRecord::Schema.define(version: 20160321021009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 20160320200142) do
     t.datetime "updated_at", null: false
     t.string   "name",       null: false
   end
+
+  add_index "categories", ["name"], name: "index_categories_on_name", unique: true, using: :btree
 
   create_table "categories_resources", id: false, force: :cascade do |t|
     t.integer "category_id", null: false


### PR DESCRIPTION
Two categories shouldn't be able to share a name. This change adds an index on the column to enforce that constraint.

We should discuss the API in a bit more detail at some point, too. It might make more sense for clients to use the category name as a category identifier rather than its `id` field.