### PR TITLE
Add Bullet gem to detect excessive queries and fix a detected instance.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a
   # debugger console
   gem 'byebug'
+  gem 'bullet'
   gem 'factory_girl_rails', '~> 4.0'
   gem 'faker', '~> 1.6'
   gem 'rspec-rails', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,9 @@ GEM
     arel (6.0.3)
     ast (2.2.0)
     builder (3.2.2)
+    bullet (5.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     byebug (8.2.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
@@ -119,6 +122,7 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unicode-display_width (1.0.2)
+    uniform_notifier (1.10.0)
 
 PLATFORMS
   ruby
@@ -127,6 +131,7 @@ DEPENDENCIES
   actionmailer (~> 4.2)
   activerecord (~> 4.2)
   activesupport (~> 4.2)
+  bullet
   byebug
   factory_girl_rails (~> 4.0)
   faker (~> 1.6)

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -4,7 +4,7 @@ class ResourcesController < ApplicationController
     result = if category_id
                resources.joins(:categories).where('categories.id' => category_id)
              else
-               Resource.all
+               resources.all
              end
 
     render json: result.to_json(resource_inclusion)
@@ -18,7 +18,8 @@ class ResourcesController < ApplicationController
   private
 
   def resources
-    Resource.includes(:addresses, :phones, :categories,
+    Resource.includes(:addresses, :phones, :categories, :notes,
+                      services: [:notes, { schedule: :schedule_days }],
                       schedule: :schedule_days)
   end
 

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,0 +1,9 @@
+unless Rails.env.production?
+  Rails.application.configure do
+    config.after_initialize do
+      Bullet.enable = Rails.env.test? # Only enable Bullet during testing.
+      Bullet.bullet_logger = true
+      Bullet.raise = true
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'factory_girl_rails'
+require 'active_record'
+require 'bullet'
 
 module RequestSpecHelpers
   def response_json
@@ -99,5 +101,16 @@ RSpec.configure do |config|
     # test failures related to randomization by passing the same `--seed` value
     # as the one that triggered the failure.
     Kernel.srand config.seed
+  end
+
+  if Bullet.enable?
+    config.before(:each) do
+      Bullet.start_request
+    end
+
+    config.after(:each) do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
   end
 end


### PR DESCRIPTION
This adds https://github.com/flyerhzm/bullet to the project, enabling it during tests, to help catch requests that produce excessive queries due to missing eager loading. Tests will fail if a problem like this is detected.