### PR TITLE
docker-compose development flow

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,1 @@
+FROM ruby:2.3.0-onbuild

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # askdarcel-api [![Build Status](https://travis-ci.org/ShelterTechSF/askdarcel-api.svg?branch=master)](https://travis-ci.org/ShelterTechSF/askdarcel-api)
 
-## Set-up Instructions
+## macOS Set-up Instructions
 
 ### Install Dependencies
 
@@ -29,3 +29,32 @@ After cloning the repository and `cd`ing into the workspace:
   - `bin/rake db:create db:schema:load db:populate`
 4. Run the development server.
   - `bin/rails s -b 0.0.0.0`
+
+
+## Docker-based Development Set-up Instructions
+
+### Requirements
+
+Docker Engine >= 1.10
+Docker Compose >= 1.6
+
+Follow the [Docker installation instructions](https://www.docker.com/products/overview) for your OS.
+
+### Set up the project
+
+This is not a full guide to Docker and Docker Compose, so please consult other
+guides to learn more about those tools.
+
+```sh
+# Start the database container (in the background with -d)
+$ docker-compose up -d db
+
+# Populate the initial development database
+$ docker-compose run --rm api rake db:create db:schema:load linksf:import
+
+# Start the Rails development server in the api container (in the foreground)
+$ docker-compose up api
+
+# To stop all containers, including background ones
+$ docker-compose stop
+```

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,6 +24,7 @@ default: &default
 development:
   <<: *default
   database: askdarcel_development
+  url: <%= ENV['DATABASE_URL'] %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -58,6 +59,7 @@ development:
 test:
   <<: *default
   database: askdarcel_test
+  url: <%= ENV['TEST_DATABASE_URL'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2"
+services:
+  db:
+    image: "postgres:9.5"
+
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: rails server --port=3000 --binding=0.0.0.0
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgres://postgres@db/askdarcel_development
+      TEST_DATABASE_URL: postgres://postgres@db/askdarcel_test
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/usr/src/app


### PR DESCRIPTION
I prefer a Docker-based development workflow, since it solves a lot of problems with making sure the right versions of different requirements are installed. I've added a `docker-compose.yml` file that orchestrates a two-container setup, with one database container and one web (Rails) container.

I couldn't get the existing Dockerfile to work. Here's the error I was getting when trying to build it:

```
Building web
Step 1 : FROM ad2games/docker-rails:2.1.1
# Executing 6 build triggers...
Step 1 : COPY Gemfile Gemfile.lock /home/app/webapp/
 ---> Using cache
Step 1 : RUN chown app:app Gemfile Gemfile.lock &&   chpst -u app bundle install --deployment --jobs 4 --without development test &&   find vendor/bundle -name *.gem -delete
 ---> Using cache
Step 1 : COPY . /home/app/webapp/
Step 1 : RUN mkdir -p db public/assets log tmp vendor
 ---> Running in e30d22f6da71
Step 1 : RUN chown -R app:app app db public log tmp vendor
 ---> Running in 5259b9315102
Step 1 : RUN bash -ec   "if chpst -u app bundle show sprockets; then     touch .env; source .env;     chpst -u app bundle exec rake assets:precompile       SECRET_KEY_BASE=noop DATABASE_URL=postgres://noop ;   fi"
 ---> Running in 29b1f251a93a
/home/app/webapp/vendor/bundle/ruby/2.3.0/gems/sprockets-3.7.0
rake aborted!
PG::ConnectionBad: could not translate host name "noop" to address: Name or service not known
```

Since I didn't want to mess with the existing Dockerfile, in case if that's how the production site is run, I used the `ruby:2.3.0-onbuild` image, which functions similarly enough. Let me know if there's a simple way to fix my problem, and I'll gladly get rid of the second Dockerfile I added.