### PR TITLE
Add verified_at field to both Resource and Service models.

### DIFF
--- a/app/presenters/resources_presenter.rb
+++ b/app/presenters/resources_presenter.rb
@@ -4,6 +4,7 @@ class ResourcesPresenter < Jsonite
   property :short_description
   property :long_description
   property :website
+  property :verified_at
   property :services, with: ServicesPresenter
   property :schedule, with: SchedulesPresenter
   property :phones, with: PhonesPresenter

--- a/app/presenters/services_presenter.rb
+++ b/app/presenters/services_presenter.rb
@@ -6,6 +6,7 @@ class ServicesPresenter < Jsonite
   property :required_documents
   property :fee
   property :application_process
+  property :verified_at
   property :schedule, with: SchedulesPresenter
   property :notes, with: NotesPresenter
 end

--- a/db/migrate/20170121235411_add_verified_at_to_resources_and_add_verified_at_to_services.rb
+++ b/db/migrate/20170121235411_add_verified_at_to_resources_and_add_verified_at_to_services.rb
@@ -1,0 +1,6 @@
+class AddVerifiedAtToResourcesAndAddVerifiedAtToServices < ActiveRecord::Migration[5.0]
+  def change
+    add_column :resources, :verified_at, :datetime
+    add_column :services, :verified_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161208022001) do
+ActiveRecord::Schema.define(version: 20170121235411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(version: 20161208022001) do
     t.string   "short_description"
     t.text     "long_description"
     t.string   "website"
+    t.datetime "verified_at"
   end
 
   create_table "reviews", force: :cascade do |t|
@@ -181,6 +182,7 @@ ActiveRecord::Schema.define(version: 20161208022001) do
     t.decimal  "fee"
     t.text     "application_process"
     t.integer  "resource_id"
+    t.datetime "verified_at"
     t.index ["resource_id"], name: "index_services_on_resource_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,6 @@
 
 
 ActiveRecord::Schema.define(version: 20170121235411) do
-ActiveRecord::Schema.define(version: 20170112020108) do
 
 
   # These are extensions that must be enabled in order to support this database


### PR DESCRIPTION
Fixes #127. This adds a migration that adds a `verified_at` field to both the Resource and Service models, and it updates the presenters to return that field as part of the API endpoints. I wasn't sure about how we wanted to change the API to support verifying resources with making any changes, but currently it can be done by having the frontend explicitly set the `verified_at` field.