### PR TITLE
Run Postman tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ services:
 rvm:
 - 2.3.0
 
+node_js:
+  - "6"
+
 cache: bundler
 
 addons:
@@ -22,9 +25,16 @@ env:
     - SANITIZED_BRANCH=$(echo $TRAVIS_BRANCH|sed 's|/|-|g')
     - REPO=sheltertechsf/askdarcel-api
 
+install:
+  # bundle install command copied from Travis's default install.bundler
+  - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
+  - npm install -g newman
+
 before_script: bundle exec rake db:create db:schema:load
 
-script: bundle exec rake rubocop spec
+script:
+  - bundle exec rake rubocop spec
+  - ./travis/postman.sh
 
 after_success:
   - echo 'export DATABASE_URL="'$PRECOMPILE_DATABASE_URL'"' >> .env

--- a/Dockerfile.dev.postman
+++ b/Dockerfile.dev.postman
@@ -1,0 +1,4 @@
+FROM node:6.10
+
+RUN npm install -g newman
+WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -60,3 +60,13 @@ $ docker-compose up api
 # To stop all containers, including background ones
 $ docker-compose stop
 ```
+
+### Running Postman tests from the command line
+
+```sh
+# Refresh DB
+$ docker-compose run --rm api rake db:create db:schema:load linksf:import
+
+# Run Docker container that executes Postman CLI tool named newman
+$ docker-compose run --rm postman
+```

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -136,7 +136,7 @@ class ChangeRequestsController < ApplicationController
     ChangeRequest.includes(:field_changes, resource: [
                              :address, :phones, :categories, :notes,
                              schedule: :schedule_days,
-                             services: [:notes, { schedule: :schedule_days }],
+                             services: [:notes, :categories, { schedule: :schedule_days }],
                              ratings: [:review]])
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,13 @@ services:
       - "3000:3000"
     volumes:
       - .:/usr/src/app
+
+  postman:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev.postman
+    command: bash -c 'sleep 3 && curl -v http://api:3000/resources?category_id=1 >/dev/null && newman run -e postman/docker.postman_environment.json -g postman/globals.postman_globals.json postman/AskDarcel%20API.postman_collection.json && newman run -e postman/docker.postman_environment.json -g postman/globals.postman_globals.json postman/AskDarcel%20Admin%20API.postman_collection.json'
+    depends_on:
+      - api
+    volumes:
+      - .:/usr/src/app

--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -23,7 +23,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/resources",
+				"url": "{{base_url}}/resources",
 				"method": "GET",
 				"header": [
 					{
@@ -45,7 +45,7 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"tests[\"Response time is less than 1500ms\"] = responseTime < 1500;",
 							"",
 							"tests[\"Status code is 200\"] = responseCode.code === 200;"
 						]
@@ -53,7 +53,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/resources?category_id=1",
+				"url": "{{base_url}}/resources?category_id=1",
 				"method": "GET",
 				"header": [
 					{
@@ -83,7 +83,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/resources/1",
+				"url": "{{base_url}}/resources/1",
 				"method": "GET",
 				"header": [
 					{
@@ -113,7 +113,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/categories",
+				"url": "{{base_url}}/categories",
 				"method": "GET",
 				"header": [
 					{
@@ -135,7 +135,7 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"tests[\"Response time is less than 1500ms\"] = responseTime < 1500;",
 							"",
 							"tests[\"Status code is 200\"] = responseCode.code === 200;"
 						]
@@ -143,7 +143,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/resources/search?query=food",
+				"url": "{{base_url}}/resources/search?query=food",
 				"method": "GET",
 				"header": [
 					{
@@ -165,7 +165,7 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"tests[\"Response time is less than 1500ms\"] = responseTime < 1500;",
 							"",
 							"tests[\"Status code is 200\"] = responseCode.code === 200;"
 						]
@@ -173,7 +173,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/resources?category_id=1&lat=100&long=100",
+				"url": "{{base_url}}/resources?category_id=1&lat=100&long=100",
 				"method": "GET",
 				"header": [
 					{
@@ -195,7 +195,7 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"tests[\"Response time is less than 1500ms\"] = responseTime < 1500;",
 							"",
 							"tests[\"Status code is 200\"] = responseCode.code === 200;"
 						]
@@ -203,7 +203,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/resources/search?query=food&lat=100&long=100",
+				"url": "{{base_url}}/resources/search?query=food&lat=100&long=100",
 				"method": "GET",
 				"header": [
 					{
@@ -233,7 +233,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/resources/1/change_requests",
+				"url": "{{base_url}}/resources/1/change_requests",
 				"method": "POST",
 				"header": [
 					{
@@ -271,7 +271,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/services/1/change_requests",
+				"url": "{{base_url}}/services/1/change_requests",
 				"method": "POST",
 				"header": [
 					{
@@ -309,7 +309,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/schedule_days/1/change_requests",
+				"url": "{{base_url}}/schedule_days/1/change_requests",
 				"method": "POST",
 				"header": [
 					{
@@ -347,7 +347,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/notes/1/change_requests",
+				"url": "{{base_url}}/notes/1/change_requests",
 				"method": "POST",
 				"header": [
 					{
@@ -385,7 +385,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/phones/1/change_requests",
+				"url": "{{base_url}}/phones/1/change_requests",
 				"method": "POST",
 				"header": [
 					{
@@ -423,7 +423,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/addresses/1/change_requests",
+				"url": "{{base_url}}/addresses/1/change_requests",
 				"method": "POST",
 				"header": [
 					{

--- a/postman/AskDarcel%20Admin%20API.postman_collection.json
+++ b/postman/AskDarcel%20Admin%20API.postman_collection.json
@@ -24,7 +24,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/admin/auth/sign_in",
+				"url": "{{base_url}}/admin/auth/sign_in",
 				"method": "POST",
 				"header": [
 					{
@@ -49,7 +49,7 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"tests[\"Response time is less than 8000ms\"] = responseTime < 8000;",
 							"",
 							"tests[\"Status code is 200\"] = responseCode.code === 200;"
 						]
@@ -57,7 +57,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/change_requests",
+				"url": "{{base_url}}/change_requests",
 				"method": "GET",
 				"header": [
 					{
@@ -102,7 +102,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/change_requests/1/approve",
+				"url": "{{base_url}}/change_requests/1/approve",
 				"method": "POST",
 				"header": [
 					{
@@ -147,7 +147,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/change_requests/2/reject",
+				"url": "{{base_url}}/change_requests/2/reject",
 				"method": "POST",
 				"header": [
 					{
@@ -192,7 +192,7 @@
 				}
 			],
 			"request": {
-				"url": "http://askdarcel.lvh.me:3000/admin/auth/sign_out",
+				"url": "{{base_url}}/admin/auth/sign_out",
 				"method": "DELETE",
 				"header": [
 					{

--- a/postman/AskDarcel%20Admin%20API.postman_collection.json
+++ b/postman/AskDarcel%20Admin%20API.postman_collection.json
@@ -49,7 +49,7 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"tests[\"Response time is less than 8000ms\"] = responseTime < 8000;",
+							"tests[\"Response time is less than 12000ms\"] = responseTime < 12000;",
 							"",
 							"tests[\"Status code is 200\"] = responseCode.code === 200;"
 						]

--- a/postman/docker.postman_environment.json
+++ b/postman/docker.postman_environment.json
@@ -1,0 +1,16 @@
+{
+  "id": "3b8b5094-780d-146e-2abd-0dc575aef247",
+  "name": "Docker",
+  "values": [
+    {
+      "enabled": true,
+      "key": "base_url",
+      "value": "http://api:3000",
+      "type": "text"
+    }
+  ],
+  "timestamp": 1488439024516,
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2017-03-02T07:17:11.261Z",
+  "_postman_exported_using": "Postman/4.10.2"
+}

--- a/postman/globals.postman_globals.json
+++ b/postman/globals.postman_globals.json
@@ -1,0 +1,15 @@
+{
+  "id": "a9d0af1a-5b21-f477-503c-693194a5036e",
+  "name": "Postman Globals",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "http://askdarcel.lvh.me:3000",
+      "type": "text",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "globals",
+  "_postman_exported_at": "2017-03-02T07:28:09.276Z",
+  "_postman_exported_using": "Postman/4.10.2"
+}

--- a/travis/postman.sh
+++ b/travis/postman.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -ex
+
+# Set up fresh db
+bundle exec rake db:create db:schema:load linksf:import
+
+bundle exec rails server &
+rails_pid=$!
+sleep 5  # Make sure server is up before continuing
+
+# Kill Rails process on exit
+trap "kill $rails_pid" EXIT
+
+# Hit a page to force Rails to cache the loading of modules, avoiding a timeout
+# failure on the first Postman test.
+curl -v http://localhost:3000/resources?category_id=1 >/dev/null
+
+newman run -g postman/globals.postman_globals.json postman/AskDarcel%20API.postman_collection.json
+newman run -g postman/globals.postman_globals.json postman/AskDarcel%20Admin%20API.postman_collection.json


### PR DESCRIPTION
This enables the Postman tests to run as part of the Travis build using the official Postman command line tool, [newman](https://github.com/postmanlabs/newman). Aside from all the scripting glue to run everything, I had to modify the Postman scripts in a few ways:

In order to get my local Docker environment to run the tests, I had to factor out the base URL referenced in the Postman scripts as a parameter, since in a Docker environment, the Rails server will be running in a different container than the test runner, so localhost or the `lvh.me` domain won't work. This required adding both a Postman global variable file and an environment file for Docker. The globals file acts as a way to set default values, and the environment allows you to override them.

I also had to bump up the timeouts for several tests because some of the test cases are really slow. The change requests test is particularly slow because we create hundreds of change requests when we initialize the DB with linksf data, and it does many deep joins to other tables. Some of the timeouts may not be enough, since there is some variance in the actual request times when run on Travis.

I also caught a small problem with not prefetching enough in the change requests list controller, where we weren't prefetching the link between services and categories.