### PR TITLE
Add db:data:dump and db:data:load Rake tasks.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,13 @@
 FROM ad2games/docker-rails:2.5.0
+
+# ad2games/docker-rails removes files required for dpkg to work. We must
+# recreate those files first before we can install postgresql-client.
+# See this StackExchange question on restoring dpkg files:
+# http://askubuntu.com/questions/383339/how-to-recover-deleted-dpkg-directory
+RUN mkdir -p /var/lib/dpkg/alternatives /var/lib/dpkg/info /var/lib/dpkg/parts /var/lib/dpkg/triggers /var/lib/dpkg/updates && \
+  touch /var/lib/dpkg/status && \
+  echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
+  curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+  apt-get update && \
+  apt-get install -y postgresql-client-9.5 && \
+  rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,1 +1,7 @@
 FROM ruby:2.3.0-onbuild
+
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+  apt-get update && \
+  apt-get install -y postgresql-client-9.5 && \
+  rm -rf /var/lib/apt/lists/*

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,28 @@
+namespace :db do
+  namespace :data do
+    task :dump, [:filename] => :environment do |_t, args|
+      args.with_defaults(filename: 'db.sql')
+      DBTasks.set_psql_env!
+      raise "Error dumping database" unless system("pg_dump --file '#{args.filename}'")
+    end
+
+    task :load, [:filename] => :environment do |_t, args|
+      raise 'Refusing to run in production!' if Rails.env.production?
+      args.with_defaults(filename: 'db.sql')
+      DBTasks.set_psql_env!
+      raise "Error loading database" unless system("psql < '#{args.filename}'")
+    end
+  end
+end
+
+# Adapted from ActiveRecord::Tasks::PostgreSQLDatabaseTasks
+class DBTasks
+  def self.set_psql_env!
+    config = ActiveRecord::Base.connection_config
+    ENV['PGHOST'] = config[:host] if config[:host]
+    ENV['PGPORT'] = config[:port].to_s if config[:port]
+    ENV['PGPASSWORD'] = config[:password] if config[:password]
+    ENV['PGUSER'] = config[:username] if config[:username]
+    ENV['PGDATABASE'] = config[:database] if config[:database]
+  end
+end


### PR DESCRIPTION
This adds a pair of Rake tasks for dumping and loading a database, allowing us to periodically dump the production DB for use in local environments. It uses the `pg_dump` and `psql` commands that Postgres already comes with to do this, and the tasks are simple wrappers for them.

The trickiest part of this PR was figuring out how to get `pg_dump` and `psql` installed in the Docker containers. The client libraries must match the major and minor version of the server, and it so happens that neither the production nor development Docker images use Linux distros that actually use Postgres 9.5, so we have to add a thirdparty apt repository (the official ones managed by Postgres) in order to install 9.5. This was also complicated by the fact that the base Docker image used by production uses Ubuntu 16.04 (Xenial) while the development one uses Debian 8 (Jessie), so the instructions are slightly different.

Lastly, the production Docker image purges a lot of files in order to minimize the image size, which unfortunately includes removing a lot of files that track the internal state of `dpkg`. This makes it impossible to `apt-get install` new packages. I had to find a StackExchange post that described how to fix a machine that has had its `/var/lib/dpkg` directory removed, which appears to have worked for me.

I don't have access to our production DB, so I couldn't test it there, but I can confirm that the Rake tasks work for me in the dev Docker environment and that I can build the production Docker image, after working around that database issue with Devise.

BTW, I submitted https://github.com/lynndylanhurley/devise_token_auth/pull/843, which should let us get rid of the line in the Travis config to set up the database URL before building the Docker container.