### PR TITLE
Algolia Search Backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem 'puma'
 gem 'phonelib'
 gem 'faker', '~> 1.6'
 
+# Search Provider
+gem 'algoliasearch-rails', '~> 1.19.1'
+
 group :production do
   gem 'activerecord-nulldb-adapter'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,12 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    algoliasearch (1.12.7)
+      httpclient (~> 2.8.3)
+      json (>= 1.5.1)
+    algoliasearch-rails (1.19.1)
+      algoliasearch (~> 1.12.4)
+      json (>= 1.5.1)
     arel (7.1.2)
     ast (2.3.0)
     bcrypt (3.1.11)
@@ -74,7 +80,9 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashie (3.4.6)
+    httpclient (2.8.3)
     i18n (0.7.0)
+    json (2.1.0)
     jsonite (0.0.3)
       activesupport (>= 3.1.0)
     loofah (2.0.3)
@@ -183,6 +191,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-nulldb-adapter
+  algoliasearch-rails (~> 1.19.1)
   bullet
   byebug
   devise_token_auth
@@ -201,4 +210,4 @@ DEPENDENCIES
   spring
 
 BUNDLED WITH
-   1.13.6
+   1.15.0

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -16,7 +16,7 @@ class ResourcesController < ApplicationController
 
   def search
     result = Resources::Search.perform(params.require(:query), sort_order, scope: resources)
-    render json: ResourcesPresenter.present(result)
+    render json: {resources: ResourcesPresenter.present(result)}
   end
 
   private

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,5 +2,5 @@ class Address < ActiveRecord::Base
   acts_as_mappable distance_field_name: :distance,
                    lat_column_name: :latitude,
                    lng_column_name: :longitude
-  belongs_to :resource
+  belongs_to :resource, touch: true
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,4 +1,4 @@
 class Note < ActiveRecord::Base
-  belongs_to :resource
+  belongs_to :resource, touch: true
   belongs_to :service
 end

--- a/app/models/phone.rb
+++ b/app/models/phone.rb
@@ -1,3 +1,3 @@
 class Phone < ActiveRecord::Base
-  belongs_to :resource
+  belongs_to :resource, touch: true
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,4 +1,8 @@
 class Resource < ActiveRecord::Base
+  include AlgoliaSearch
+
+  delegate :latitude, :longitude, to: :address, prefix: true, allow_nil: true
+
   has_and_belongs_to_many :categories
   has_and_belongs_to_many :keywords
   has_one :address
@@ -8,4 +12,39 @@ class Resource < ActiveRecord::Base
   has_many :services
   has_many :ratings
   has_many :change_requests
+
+  algoliasearch do
+    geoloc :address_latitude, :address_longitude
+
+    add_attribute :address do
+      if address.present?
+        {
+          city: address.city,
+          state_province: address.state_province,
+          postal_code: address.postal_code,
+          country: address.country,
+        }
+      else
+        {}
+      end
+    end
+
+    add_attribute :notes do
+     notes.map {|n| n.note } 
+    end
+
+    add_attribute :categories do
+      categories.map {|c| c.name }
+    end
+
+    add_attribute :keywords do
+     keywords.map {|k| k.name }
+    end
+
+    add_attribute :services do
+      services.map {|s| {
+        name: s.name,
+      }}
+    end
+  end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -13,7 +13,7 @@ class Resource < ActiveRecord::Base
   has_many :ratings
   has_many :change_requests
 
-  algoliasearch do
+  algoliasearch per_environment: true do
     geoloc :address_latitude, :address_longitude
 
     add_attribute :address do

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,5 @@
 class Schedule < ActiveRecord::Base
-  belongs_to :resource
+  belongs_to :resource, touch: true
   belongs_to :service
   has_many :schedule_days
   has_one :note

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,7 +1,7 @@
 class Service < ActiveRecord::Base
   enum status: { pending: 0, approved: 1, rejected: 2 }
 
-  belongs_to :resource, required: true
+  belongs_to :resource, required: true, touch: true
   has_many :notes
   has_one :schedule
   has_and_belongs_to_many :categories

--- a/app/services/resources/search.rb
+++ b/app/services/resources/search.rb
@@ -1,38 +1,7 @@
 module Resources
   class Search
-    SEARCH_CONFIG = 'english'.freeze
-
-    # SEARCH_COLUMNS maps table names to an array of the columns in
-    # that table to search.
-    SEARCH_COLUMNS = {
-      resources: %i(
-        name
-        short_description
-        long_description
-        website
-      ).freeze,
-      services: :long_description,
-      notes: :note,
-      categories: :name
-    }.freeze
-
-    CLAUSE = SEARCH_COLUMNS.map do |t, cols|
-      Array.wrap(cols).map do |c|
-        "to_tsvector('#{SEARCH_CONFIG}', coalesce(#{t}.#{c}, ''))"
-      end
-    end.flatten.join('||').freeze
-
     def self.perform(query, sort, scope: Resource)
-      sort = 'resources.name' unless sort
-
-      scope
-        .left_outer_joins(:services)
-        .left_outer_joins(:notes)
-        .left_outer_joins(:categories)
-        .left_outer_joins(:address)
-        .where("#{CLAUSE} @@ plainto_tsquery('#{SEARCH_CONFIG}', ?)", query)
-        .group('resources.id, addresses.latitude, addresses.longitude')
-        .order(sort)
+      scope.algolia_search(query)
     end
   end
 end

--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -1,0 +1,4 @@
+AlgoliaSearch.configuration = {
+  application_id: ENV['ALGOLIA_APPLICATION_ID'],
+  api_key: ENV['ALGOLIA_API_KEY']
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     environment:
       DATABASE_URL: postgres://postgres@db/askdarcel_development
       TEST_DATABASE_URL: postgres://postgres@db/askdarcel_test
+      ALGOLIA_APPLICATION_ID:
+      ALGOLIA_API_KEY:
     ports:
       - "3000:3000"
     volumes:

--- a/lib/tasks/algolia.rake
+++ b/lib/tasks/algolia.rake
@@ -1,0 +1,7 @@
+namespace :algolia do
+  task :reindex => :environment do
+    print "Reindexing resources... "
+    Resource.reindex
+    puts "success."
+  end
+end


### PR DESCRIPTION
## What is this? Why?

Search backed by Algolia, allowing fuzzy matching and configuration of search ranking through algolia's backend.

- [x] Indexing for Resources 
- [x] Configure `/resources/search` to use Algolia
- [x] Rake task for for initial production indexing
- [x] Add `touch: true` to nested models so that they trigger an update of the Resources index.
- [ ] Setup production Algolia account
- [ ] Strategy for managing secrets? Currently I've stashed them in `.env` locally, not sure how we're doing this on production.
- [ ] Testing (mock algolia?)

@jjfreund please take a look.

Feature complete, needs tests, review and QA.