### PR TITLE
Allow adding change request for new phone number.

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -37,7 +37,7 @@ class ChangeRequestsController < ApplicationController
     if !admin_signed_in?
       render status: :unauthorized
     else
-      render json: ChangeRequestsPresenter.present(changerequest.pending)
+      render json: ChangeRequestsWithResourcePresenter.present(changerequest.pending)
     end
   end
 

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -6,8 +6,9 @@ class ChangeRequestsController < ApplicationController
       @change_request = ServiceChangeRequest.create(object_id: params[:service_id], resource_id: Service.find(params[:service_id]).resource_id)
     elsif params[:address_id]
       @change_request = AddressChangeRequest.create(object_id: params[:address_id], resource_id: Address.find(params[:address_id]).resource_id)
-    elsif params[:phone_id]
-      @change_request = PhoneChangeRequest.create(object_id: params[:phone_id], resource_id: Phone.find(params[:phone_id]).resource_id)
+    elsif params[:phone_id] || params[:type] == 'phones'
+      resource_id = params[:parent_resource_id] || Phone.find(params[:phone_id]).resource_id
+      @change_request = PhoneChangeRequest.create(object_id: params[:phone_id], resource_id: resource_id)
     elsif params[:schedule_day_id]
       schedule = Schedule.find(ScheduleDay.find(params[:schedule_day_id]).schedule_id)
       if (schedule.resource_id)
@@ -22,6 +23,9 @@ class ChangeRequestsController < ApplicationController
       else
         @change_request = NoteChangeRequest.create(object_id: params[:note_id], resource_id: Service.find(note.service_id).resource_id)
       end
+    else
+      render status: :bad_request
+      return
     end
 
     @change_request.field_changes = field_changes
@@ -89,36 +93,38 @@ class ChangeRequestsController < ApplicationController
   def persist_change(change_request)
     object_id = change_request.object_id
     puts object_id
+    field_change_hash = get_field_change_hash change_request
 
     if change_request.is_a? ServiceChangeRequest
       puts 'ServiceChangeRequest'
       service = Service.find(change_request.object_id)
-      field_change_hash = get_field_change_hash change_request
       service.update field_change_hash
     elsif change_request.is_a? ResourceChangeRequest
       puts 'ResourceChangeRequest'
       resource = Resource.find(change_request.object_id)
-      field_change_hash = get_field_change_hash change_request
       resource.update field_change_hash
     elsif change_request.is_a? ScheduleDayChangeRequest
       puts 'ScheduleDayChangeRequest'
       schedule_day = ScheduleDay.find(change_request.object_id)
-      field_change_hash = get_field_change_hash change_request
       schedule_day.update field_change_hash
     elsif change_request.is_a? NoteChangeRequest
       puts 'NoteChangeRequest'
       note = Note.find(change_request.object_id)
-      field_change_hash = get_field_change_hash change_request
       note.update field_change_hash
     elsif change_request.is_a? PhoneChangeRequest
       puts 'PhoneChangeRequest'
-      phone = Phone.find(change_request.object_id)
-      field_change_hash = get_field_change_hash change_request
+      if change_request.object_id
+        phone = Phone.find(change_request.object_id)
+      else
+        phone = Phone.new(resource_id: change_request.resource_id, service_type: '')
+      end
+      if field_change_hash["number"]
+        field_change_hash["number"] = Phonelib.parse(field_change_hash["number"], 'US').full_e164
+      end
       phone.update field_change_hash
     elsif change_request.is_a? AddressChangeRequest
       puts 'AddressChangeRequest'
       address = Address.find(change_request.object_id)
-      field_change_hash = get_field_change_hash change_request
       address.update field_change_hash
     else
       puts 'invalid request'

--- a/app/presenters/change_requests_presenter.rb
+++ b/app/presenters/change_requests_presenter.rb
@@ -4,5 +4,8 @@ class ChangeRequestsPresenter < Jsonite
   property :type
   property :object_id
   property :field_changes, with: FieldChangesPresenter
+end
+
+class ChangeRequestsWithResourcePresenter < ChangeRequestsPresenter
   property :resource, with: ResourcesPresenter
 end

--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -579,6 +579,44 @@
 				"description": ""
 			},
 			"response": []
+		},
+		{
+			"name": "Add Phone to Resource",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"",
+							"tests[\"Status code is 201\"] = responseCode.code === 201;"
+						]
+					}
+				}
+			],
+			"request": {
+				"url": "{{base_url}}/change_requests",
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"description": ""
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{  \n\t\"change_request\": {\n\t\t\"number\": \"(415) 555-5555\",\n\t\t\"service_type\": \"general inquiries\"\n\t},\n\t\"type\": \"phones\",\n\t\"parent_resource_id\": 1\n}"
+				},
+				"description": ""
+			},
+			"response": []
 		}
 	]
 }


### PR DESCRIPTION
Here I'm proposing that we leverage ChangeRequests to support creating new model instances, as opposed to only supporting changes to already existing models. It looks like the `object_id` field on ChangeRequests is already nullable, so all I had to do was update the controller logic to create a new object if `object_id` is nil.

I had to add two new, backwards-compatible parameters to the API:
- `type`, which should be the (plural) name of the model being changed
- `parent_resource_id`, which should be the ID of the Resource that the model belongs to

`type` was necessary because we can no longer rely on the presence of `phone_id` to let us know the type of model being created. `parent_resource_id` was necessary because 1) we can't look up the Resource via the Phone, since one does not already exist in this case, and 2) `resource_id` was already used as a parameter name to imply that the proposed change request should be made on the resource itself.

These API changes are backwards compatible, since changes requests for model instances that already exist will use the existing codepaths.

I only made the API change for phone numbers. It's going to require a bit more work to have this scheme apply to other types of models, since we may run into issues with database column constraints. Phone's `service_type` field is not nullable, which means that we need to initialize it to the empty string prior to applying the field changes.

I have another branch that I'm working on to actually add in this new API call in the frontend, but from an API perspective, these changes are sufficient for me to make an edit and approve it via the admin page.