### PR TITLE
Fix change request presenter import error

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -37,7 +37,7 @@ class ChangeRequestsController < ApplicationController
     if !admin_signed_in?
       render status: :unauthorized
     else
-      render json: ChangeRequestsPresenter.present(changerequest.pending)
+      render json: ChangeRequestsWithResourcePresenter.present(changerequest.pending)
     end
   end
 

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -1,3 +1,5 @@
+require_relative '../presenters/change_requests_presenter'
+
 class ChangeRequestsController < ApplicationController
   def create
     if params[:resource_id]


### PR DESCRIPTION
Sorry about the bug. Rails' magic-like auto-import functionality made me miss this in testing because I probably had files import in a different order. This adds an explicit `require_relative` to the controller to make sure those models are in the global namespace by the time they are used.