### PR TITLE
Fix add categories change request

### DIFF
--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -733,6 +733,44 @@
 				"description": ""
 			},
 			"response": []
+		},
+		{
+			"name": "Add Service Category",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"",
+							"tests[\"Status code is 201\"] = responseCode.code === 201;"
+						]
+					}
+				}
+			],
+			"request": {
+				"url": "{{base_url}}/services/1/change_requests",
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"description": ""
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"change_request\": {\n\t\t\"categories\": [\n\t\t\t{\"name\": \"Food\", \"id\": 2},\n\t\t\t{\"name\": \"Health\", \"id\": 3}\n\t\t]\n\t}\n}"
+				},
+				"description": ""
+			},
+			"response": []
 		}
 	]
 }


### PR DESCRIPTION
This fixes the other issue with ShelterTechSF/askdarcel-web#307, where changes to a service's categories weren't getting persisted. The issue is that we don't actually have an API for being able to set many-to-many relationships via a change request. The ChangeRequest and FieldChange models assume that changes are always to single values, not arrays of values.

In order to make this work, I've added some hacky code paths to check if the name of the field you're changing is `categories`, and if so, serialize the array into a string via its JSON encoding. Then in the `#persist_changes` method, I deserialize the array so that it can be passed into `Model#update`.

To make sure we don't regress, I added a Postman test that fails without this patch and passes with this patch.