### PR TITLE
Pin version of newman.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   # bundle install command copied from Travis's default install.bundler
   - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
-  - npm install -g newman
+  - npm install -g newman@3.8.3
 
 before_script: bundle exec rake db:create db:schema:load
 


### PR DESCRIPTION
The latest version of newman (3.9.0) seems to be causing issues with variable substitution not working. Pinning 3.8.3 until we resolve this issue.