### PR TITLE
Fix order of arguments for newman CLI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   # bundle install command copied from Travis's default install.bundler
   - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
-  - npm install -g newman@3.8.3
+  - npm install -g newman
 
 before_script: bundle exec rake db:create db:schema:load
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev.postman
-    command: bash -c 'sleep 3 && curl -v http://api:3000/resources?category_id=1 >/dev/null && newman run -e postman/docker.postman_environment.json -g postman/globals.postman_globals.json postman/AskDarcel%20API.postman_collection.json && newman run -e postman/docker.postman_environment.json -g postman/globals.postman_globals.json postman/AskDarcel%20Admin%20API.postman_collection.json'
+    command: bash -c 'sleep 3 && curl -v http://api:3000/resources?category_id=1 >/dev/null && newman run postman/AskDarcel%20API.postman_collection.json -e postman/docker.postman_environment.json -g postman/globals.postman_globals.json && newman run postman/AskDarcel%20Admin%20API.postman_collection.json -e postman/docker.postman_environment.json -g postman/globals.postman_globals.json'
     depends_on:
       - api
     volumes:

--- a/travis/postman.sh
+++ b/travis/postman.sh
@@ -16,5 +16,5 @@ trap "kill $rails_pid" EXIT
 # failure on the first Postman test.
 curl -v http://localhost:3000/resources?category_id=1 >/dev/null
 
-newman run -g postman/globals.postman_globals.json postman/AskDarcel%20API.postman_collection.json
-newman run -g postman/globals.postman_globals.json postman/AskDarcel%20Admin%20API.postman_collection.json
+newman run postman/AskDarcel%20API.postman_collection.json -g postman/globals.postman_globals.json
+newman run postman/AskDarcel%20Admin%20API.postman_collection.json -g postman/globals.postman_globals.json


### PR DESCRIPTION
See https://github.com/postmanlabs/newman/issues/1336#issuecomment-350761746

Apparently, all command line options are supposed to come *after* the collection, though older versions of newman didn't strictly require that. With this change, I was able to unpin newman again and have the tests pass.