### PR TITLE
Add ALGOLIA_INDEX_PREFIX environment variable.

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -23,7 +23,9 @@ class Resource < ActiveRecord::Base
   end
 
   if Rails.configuration.x.algolia.enabled
-    algoliasearch per_environment: true do
+    # Note: We can't use the per_environment option because both our production
+    # and staging servers use the same RAILS_ENV.
+    algoliasearch index_name: "#{Rails.configuration.x.algolia.index_prefix}_Resource" do
       geoloc :address_latitude, :address_longitude
 
       add_attribute :address do

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,14 @@ module AskdarcelApi
     # Algolia
     config.x.algolia.application_id = ENV['ALGOLIA_APPLICATION_ID']
     config.x.algolia.api_key = ENV['ALGOLIA_API_KEY']
-    config.x.algolia.enabled = config.x.algolia.application_id.present? && config.x.algolia.api_key.present?
+    # Differentiate indexes for different AskDarcel instances.
+    config.x.algolia.index_prefix = ENV['ALGOLIA_INDEX_PREFIX']
+
+    config.x.algolia.enabled = [
+      config.x.algolia.application_id.present?,
+      config.x.algolia.api_key.present?,
+      config.x.algolia.index_prefix.present?
+    ].all?
 
     config.middleware.insert_before 0, "Rack::Cors" do
       allow do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       TEST_DATABASE_URL: postgres://postgres@db/askdarcel_test
       ALGOLIA_APPLICATION_ID:
       ALGOLIA_API_KEY:
+      ALGOLIA_INDEX_PREFIX:
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
This is a slightly different approach than what was originally proposed in https://github.com/sheltertechsf/askdarcel-api/issues/261, since the `per_environment` option just adds a `_#{Rails.env}` suffix to the indexes, and we actually use the same RAILS_ENV in both prod and staging.

Instead, I added an `ALGOLIA_INDEX_PREFIX` environment variable which is used to manually prepend a prefix to Algolia indexes. Note that we need to remember to do this with all future indexes that we create. Today, we only have a single index, so there's only one place in the code to add it, but if we add new indexes, then we need to add them to the other places.

I tested this by running it locally against our Algolia instance.