### PR TITLE
Fix ridiculous query on Resources controller

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -4,10 +4,12 @@ class ResourcesController < ApplicationController
   def index
     category_id = params.require :category_id
     # TODO: This can be simplified once we remove categories from resources
-    relation = resources.joins(:categories).joins(:address)
-                        .where('categories.id' => category_id).where(status: Resource.statuses[:approved])
-                        .order(sort_order)
-
+    relation =
+      resources
+      .joins(:address)
+      .where(categories_join_string, category_id, category_id)
+      .where(status: Resource.statuses[:approved])
+      .order(sort_order)
     render json: ResourcesPresenter.present(relation)
   end
 

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -110,10 +110,14 @@ class ResourcesController < ApplicationController
   end
 
   def resources
-    Resource.includes(:address, :phones, :categories, :notes,
-                      schedule: :schedule_days,
-                      services: [:notes, :categories, { schedule: :schedule_days }, :eligibilities],
-                      ratings: [:review])
+    # Note: We *must* use #preload instead of #includes to force Rails to make a
+    # separate query per table. Otherwise, it creates one large query with many
+    # joins, which amplifies the amount of data being sent between Rails and the
+    # DB by several orders of magnitude due to duplication of tuples.
+    Resource.preload(:address, :phones, :categories, :notes,
+                     schedule: :schedule_days,
+                     services: [:notes, :categories, { schedule: :schedule_days }, :eligibilities],
+                     ratings: [:review])
   end
 
   def sort_order

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -39,19 +39,22 @@ RSpec.describe 'Resources' do
       let(:far) { 50 }
       let(:further) { 100 }
       let!(:category) { create :category }
-      let!(:resources) { create_list :resource, 3, categories: [category] }
-      let!(:address_further) { create :address, latitude: further, longitude: 0, resource: resources[0] }
-      let!(:address_close) { create :address, latitude: close, longitude: 0, resource: resources[1] }
-      let!(:address_far) { create :address, latitude: far, longitude: 0, resource: resources[2] }
+      let!(:resources) do
+        [
+          { latitude: close, longitude: 0 },
+          { latitude: far, longitude: 0 },
+          { latitude: further, longitude: 0 }
+        ].map { |d| create(:resource, categories: [category], address: create(:address, d)) }
+      end
       it 'returns the close resource before the far resource and before the further resource' do
         get "/resources?category_id=#{category.id}&lat=#{close}&long=#{close}"
         returned_address = response_json['resources'].map { |r| r['address'] }
-        expect(returned_address[0]['latitude']).to eq(address_close.latitude.to_s('F'))
-        expect(returned_address[0]['longitude']).to eq(address_close.longitude.to_s('F'))
-        expect(returned_address[1]['latitude']).to eq(address_far.latitude.to_s('F'))
-        expect(returned_address[1]['longitude']).to eq(address_far.longitude.to_s('F'))
-        expect(returned_address[2]['latitude']).to eq(address_further.latitude.to_s('F'))
-        expect(returned_address[2]['longitude']).to eq(address_further.longitude.to_s('F'))
+        expect(returned_address[0]['latitude']).to eq(close.to_f.to_s('F'))
+        expect(returned_address[0]['longitude']).to eq(0.to_f.to_s('F'))
+        expect(returned_address[1]['latitude']).to eq(far.to_f.to_s('F'))
+        expect(returned_address[1]['longitude']).to eq(0.to_f.to_s('F'))
+        expect(returned_address[2]['latitude']).to eq(further.to_f.to_s('F'))
+        expect(returned_address[2]['longitude']).to eq(0.to_f.to_s('F'))
       end
     end
   end


### PR DESCRIPTION
Thanks to some good sleuthing by @lgarofalo, we discovered that the `/resources` endpoint was returning tens of thousands of rows, equating to around 1GB of data between the API server and the DB. This is despite the fact that our entire database is less than 1MB in size. This is likely due to massive duplication of data in each row because of the joins across many, many tables. Any one-to-many relationship would return an extra copy of the row from the "one" side for each related row on the "many" side, and many-to-many relationships are even worse.

Fortunately, we can fix this problem by forcing Rails to split up the giant query with many joins into separate queries per table. This can be done by changing the call to `#includes` with `#preload`.

This also happened to uncover a bug in an old Rspec test. Although the Resource and Address models are one-to-one with each other, there is a test that creates an additional address per resource. The test tries to join the Resources with their associated Addresses and order by the address's geolocation distance, but after making these changes, the test is accidentally picking up the wrong address now. I've corrected the test to only create one Address per Resource.