### PR TITLE
Updated algolia search to convert strings to floats

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -33,7 +33,9 @@ class Resource < ActiveRecord::Base
 
     # Important: Use Resource.reindex! and Service.reindex! to reindex/create your index
     algoliasearch index_name: "#{Rails.configuration.x.algolia.index_prefix}_services_search", id: :algolia_id do # rubocop:disable Metrics/BlockLength,Metrics/LineLength
-      geoloc :address_latitude, :address_longitude
+      add_attribute :_geoloc do
+        { lat: address_latitude.to_f, lng: address_longitude.to_f }
+      end
 
       add_attribute :status
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -30,7 +30,8 @@ class Service < ActiveRecord::Base
       add_attribute :_geoloc do
         if addresses.any?
           addresses.map do |a|
-            { lat: a.address_latitude.to_f, lng: a.address_longitude.to_f } if a.address_latitude.present? & a.address_longitude.present? # rubocop:disable Metrics/BlockLength,Metrics/LineLength
+            { lat: a.address_latitude.to_f, lng: a.address_longitude.to_f } \
+              if a.address_latitude.present? & a.address_longitude.present?
           end
         elsif resource.address.present? & resource.address_latitude.present? & resource.address_longitude.present?
           { lat: resource.address_latitude.to_f, lng: resource.address_longitude.to_f }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -30,7 +30,7 @@ class Service < ActiveRecord::Base
       add_attribute :_geoloc do
         if addresses.any?
           addresses.map do |a|
-            { lat: a.address_latitude.to_f, lng: a.address_longitude.to_f } if a.address_latitude.present? & a.address_longitude.present?
+            { lat: a.address_latitude.to_f, lng: a.address_longitude.to_f } if a.address_latitude.present? & a.address_longitude.present? # rubocop:disable Metrics/BlockLength,Metrics/LineLength
           end
         elsif resource.address.present? & resource.address_latitude.present? & resource.address_longitude.present?
           { lat: resource.address_latitude.to_f, lng: resource.address_longitude.to_f }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -30,13 +30,10 @@ class Service < ActiveRecord::Base
       add_attribute :_geoloc do
         if addresses.any?
           addresses.map do |a|
-            { lat: a.address_latitude, lng: a.address_longitude } if a.address_latitude.present? & a.address_longitude.present?
+            { lat: a.address_latitude.to_f, lng: a.address_longitude.to_f } if a.address_latitude.present? & a.address_longitude.present?
           end
         elsif resource.address.present? & resource.address_latitude.present? & resource.address_longitude.present?
-          puts 'resource:', resource.id
-          puts 'lat:', resource.address_latitude
-          puts 'lng:', resource.address_longitude
-          { lat: resource.address_latitude, lng: resource.address_longitude }
+          { lat: resource.address_latitude.to_f, lng: resource.address_longitude.to_f }
         end
       end
 


### PR DESCRIPTION
Rails will store new lat/lngs as Big Decimals and those get converted to strings when passed to Algolia. Algolia doesn't support having lat/lngs in a string format and we need to convert these Big Decimals to floats to avoid this issue.

More details can be found here: https://github.com/algolia/algoliasearch-rails/issues/125
