### PR TITLE
Add Sentry.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem 'algoliasearch-rails', '~> 1.19.1'
 # CORS
 gem 'rack-cors'
 
+# Error handling
+gem 'sentry-raven'
+
 group :production do
   gem 'activerecord-nulldb-adapter'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.6.6)
       i18n (~> 0.5)
+    faraday (0.15.3)
+      multipart-post (>= 1.2, < 3)
     geokit (1.10.0)
     geokit-rails (2.2.0)
       geokit (~> 1.5)
@@ -99,6 +101,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    multipart-post (2.0.0)
     nio4r (1.2.1)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -173,6 +176,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    sentry-raven (2.7.4)
+      faraday (>= 0.7.6, < 1.0)
     spring (1.7.2)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
@@ -216,6 +221,7 @@ DEPENDENCIES
   rspec-collection_matchers (~> 1.1)
   rspec-rails (~> 3.4)
   rubocop (~> 0.52.1)
+  sentry-raven
   spring
 
 BUNDLED WITH

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::API
   end
 
   before_action :cachable
+  before_action :set_raven_context
 
   def cachable
     expires_in 1.second, public: true, must_revalidate: false
@@ -26,5 +27,10 @@ class ApplicationController < ActionController::API
     return @current_user if defined? @current_user
     user_id = request.headers['Authorization']
     @current_user = User.where(id: user_id).first
+  end
+
+  def set_raven_context
+    Raven.user_context(id: current_user.id) if current_user
+    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Raven.configure do |config|
+  SENTRY_PUBLIC_KEY = 'd35c8b2336084e67b08f7c4b5eeb54b9'
+  SENTRY_PROJECT_ID = '1291517'
+  config.dsn = "https://#{SENTRY_PUBLIC_KEY}@sentry.io/#{SENTRY_PROJECT_ID}"
+
+  # Filter out sensitive parameters such as passwords
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+end


### PR DESCRIPTION
This is similar to https://github.com/ShelterTechSF/askdarcel-web/pull/565. Once again, there is a single project for all of `askdarcel-api`, and if that gets too noisy, we can add more projects or more tagging to filter out different events.

This will automatically send an event to Sentry if there are uncaught exceptions. We can also manually send events using `Raven.capture_exception()`, which I did test out locally: https://docs.sentry.io/clients/ruby/#reporting-failures