### PR TITLE
Avoid annoying leftover PIDs.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,10 @@ services:
       - "3000:3000"
     volumes:
       - .:/usr/src/app
+      # Avoid leftover server.pid files when container exits.
+      # https://auth0.com/blog/ruby-on-rails-killer-workflow-with-docker-part-1/
+      - type: tmpfs
+        target: /usr/src/app/tmp/pids
 
   postman:
     build:


### PR DESCRIPTION
Found a neat workaround for the annoying leftover PID thing in Rails using docker-compose: https://auth0.com/blog/ruby-on-rails-killer-workflow-with-docker-part-1/

It seems to work for me locally.