### PR TITLE
Improve change request error handling (#337)

### DIFF
--- a/spec/requests/resources/change_requests/create_spec.rb
+++ b/spec/requests/resources/change_requests/create_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe 'Resource Change Requests' do
   let(:params) do
     {
       name: 'New Name',
-      long_description: 'New Long Description',
+      long_description: 'New Long Description'
     }
   end
 
   it 'creates a change request and associated field changes' do
-    post "/resources/#{resource.id}/change_requests", { change_request: params }
+    post "/resources/#{resource.id}/change_requests", change_request: params
 
     expect(resource.reload.name).to eq(params[:name])
     expect(resource.long_description).to eq(params[:long_description])
@@ -26,7 +26,7 @@ RSpec.describe 'Resource Change Requests' do
     expect(field_changes.map(&:field_name)).to eq(%w[long_description name])
     expected_field_values = [
       params[:long_description],
-      params[:name],
+      params[:name]
     ]
     expect(field_changes.map(&:field_value)).to eq(expected_field_values)
 
@@ -38,7 +38,7 @@ RSpec.describe 'Resource Change Requests' do
         'object_id' => change_request.object_id,
         'field_changes' => [
           { 'field_name' => 'name', 'field_value' => params[:name] },
-          { 'field_name' => 'long_description', 'field_value' => params[:long_description] },
+          { 'field_name' => 'long_description', 'field_value' => params[:long_description] }
         ]
       }
     )
@@ -50,14 +50,14 @@ RSpec.describe 'Resource Change Requests' do
     end
 
     it 'rolls back changes and returns bad request status with error message' do
-      post "/resources/#{resource.id}/change_requests", { change_request: params }
+      post "/resources/#{resource.id}/change_requests", change_request: params
 
       expect(resource.change_requests).to be_empty
       expect(FieldChange.all).to be_empty
 
       expect(response).to be_bad_request
       expected_response = {
-        'error' => 'Unknown attribute in request: "not_a_real_field_name"',
+        'error' => 'Unknown attribute in request: "not_a_real_field_name"'
       }
       expect(response_json).to match(expected_response)
     end

--- a/spec/requests/resources/change_requests/create_spec.rb
+++ b/spec/requests/resources/change_requests/create_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Resource Change Requests' do
+  let(:resource) { create :resource }
+  let(:params) do
+    {
+      name: 'New Name',
+      long_description: 'New Long Description',
+    }
+  end
+
+  it 'creates a change request and associated field changes' do
+    post "/resources/#{resource.id}/change_requests", { change_request: params }
+
+    expect(resource.reload.name).to eq(params[:name])
+    expect(resource.long_description).to eq(params[:long_description])
+
+    expect(resource.change_requests).to have(1).item
+    change_request = resource.change_requests.first
+
+    expect(change_request.field_changes).to have(2).items
+    field_changes = change_request.field_changes.to_a.sort_by(&:field_name)
+
+    expect(field_changes.map(&:field_name)).to eq(%w[long_description name])
+    expected_field_values = [
+      params[:long_description],
+      params[:name],
+    ]
+    expect(field_changes.map(&:field_value)).to eq(expected_field_values)
+
+    expect(response_json).to match(
+      'resource_change_request' => {
+        'id' => change_request.id,
+        'status' => 'pending',
+        'type' => 'ResourceChangeRequest',
+        'object_id' => change_request.object_id,
+        'field_changes' => [
+          { 'field_name' => 'name', 'field_value' => params[:name] },
+          { 'field_name' => 'long_description', 'field_value' => params[:long_description] },
+        ]
+      }
+    )
+  end
+
+  context 'when an invalid change request is submitted' do
+    let(:params) do
+      { not_a_real_field_name: 'invalid field value' }
+    end
+
+    it 'rolls back changes and returns bad request status with error message' do
+      post "/resources/#{resource.id}/change_requests", { change_request: params }
+
+      expect(resource.change_requests).to be_empty
+      expect(FieldChange.all).to be_empty
+
+      expect(response).to be_bad_request
+      expected_response = {
+        'error' => 'Unknown attribute in request: "not_a_real_field_name"',
+      }
+      expect(response_json).to match(expected_response)
+    end
+  end
+end


### PR DESCRIPTION
Before, when a client submitted a change request containing an invalid
field, the API would return a 500 Internal Server Error status code, and
invalid ChangeRequest and FieldChange records would remain in the
database afterward.

Now, when a client submits a change request containing an invalid field,
the API returns a 400 Bad Request status along with an error message
describing the incorrect field. Additionally, the entire operation is
wrapped in a Postgres transaction, so invalid ChangeRequest and
FieldChange records inserts are rolled back when validation errors
occur.