### PR TITLE
Update the Algolia index whenever a change request is approved.

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -200,6 +200,12 @@ class ChangeRequestsController < ApplicationController
     else
       puts 'invalid request'
     end
+
+    if Rails.configuration.x.algolia.enabled
+      # Update Algolia index for both the resource and all its services
+      change_request.resource&.index!
+      change_request.resource&.services.each &:index!
+    end
   end
 
   def get_field_change_hash(change_request)


### PR DESCRIPTION
There have been some reports of the Algolia cache not being properly invalidated. Although the [`algoliasearch-rails`](https://github.com/algolia/algoliasearch-rails#notes) gem will automatically update the index when a model is saved, this will obviously not kick in if a related model is updated despite the fact that our model's index may rely on values from related objects.

For instance, Resources can have many Notes, and we include all of a Resource's Notes' contents in the Algolia index of that Resource. When a Note is updated, it will not automatically trigger an update to the Resource's Algolia index.

In this PR, I added a hook to the `ChangeRequestsController` such that whenever a ChangeRequest is persisted, we attempt to call the `#index!` method on both the Resource and all of the Services associated with the Resource.

I tested this locally by logging into our Algolia account and checking that the index would get updated even if I made a changed to a related model.