### PR TITLE
Add open_times to Algolia index.

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -64,6 +64,10 @@ class Resource < ActiveRecord::Base
         end
       end
 
+      add_attribute :open_times do
+        schedule&.algolia_open_times
+      end
+
       add_attribute :resource_id
 
       add_attribute :type

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,9 +1,59 @@
 # frozen_string_literal: true
 
+require 'sheltertech/time'
+
 class Schedule < ActiveRecord::Base
   belongs_to :resource, touch: true
   belongs_to :service
   has_many :schedule_days, dependent: :destroy
 
   accepts_nested_attributes_for :schedule_days
+
+  # Format open times for use in Algolia index e.g. "M-8:00"
+  def algolia_open_times
+    block_size = 30
+    schedule_days.flat_map do |day|
+      opens_at_minutes = ShelterTech::Time.hhmm_to_minutes(day.opens_at)
+      closes_at_minutes = ShelterTech::Time.hhmm_to_minutes(day.closes_at)
+      opens_at = round_time(opens_at_minutes, block_size, :down)
+      closes_at = round_time(closes_at_minutes, block_size, :up)
+      (opens_at..closes_at).step(block_size).map do |time|
+        format_algolia_open_time(day.day, time)
+      end
+    end
+  end
+
+  private
+
+  # Round time to the nearest block (e.g. round_time(89, 30, :down) == 60).
+  # Time is represented as an absolute number of minutes since midnight for
+  # simplicity.
+  def round_time(minutes, block_size, direction)
+    case direction
+    when :up
+      minutes / block_size * block_size
+    when :down
+      ((minutes - 1) / block_size + 1) * block_size
+    else
+      raise ArgumentError, "Invalid rounding direction: #{direction}"
+    end
+  end
+
+  def format_algolia_open_time(day, time_in_minutes)
+    time = Time.at(time_in_minutes * 60).getutc
+    formatted_time = time.strftime("%k:%M").strip
+    "#{day_abbreviation(day)}-#{formatted_time}"
+  end
+
+  def day_abbreviation(day)
+    {
+      'Monday' => 'M',
+      'Tuesday' => 'Tu',
+      'Wednesday' => 'W',
+      'Thursday' => 'Th',
+      'Friday' => 'F',
+      'Saturday' => 'Sa',
+      'Sunday' => 'Su'
+    }.fetch(day)
+  end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -17,7 +17,7 @@ class Schedule < ActiveRecord::Base
       closes_at_minutes = ShelterTech::Time.hhmm_to_minutes(day.closes_at)
       opens_at = round_time(opens_at_minutes, block_size, :down)
       closes_at = round_time(closes_at_minutes, block_size, :up)
-      (opens_at..closes_at).step(block_size).map do |time|
+      (opens_at...closes_at).step(block_size).map do |time|
         format_algolia_open_time(day.day, time)
       end
     end
@@ -30,9 +30,9 @@ class Schedule < ActiveRecord::Base
   # simplicity.
   def round_time(minutes, block_size, direction)
     case direction
-    when :up
-      minutes / block_size * block_size
     when :down
+      minutes / block_size * block_size
+    when :up
       ((minutes - 1) / block_size + 1) * block_size
     else
       raise ArgumentError, "Invalid rounding direction: #{direction}"

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -78,7 +78,7 @@ class Service < ActiveRecord::Base
       end
 
       add_attribute :open_times do
-        if schedule.nil?
+        if use_resource_schedule
           resource.schedule&.algolia_open_times
         else
           schedule.algolia_open_times

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -77,6 +77,14 @@ class Service < ActiveRecord::Base
         end
       end
 
+      add_attribute :open_times do
+        if schedule.nil?
+          resource.schedule&.algolia_open_times
+        else
+          schedule.algolia_open_times
+        end
+      end
+
       add_attribute :resource_schedule do
         if resource.schedule.present?
           resource.schedule.schedule_days.map do |s|

--- a/lib/sheltertech/time.rb
+++ b/lib/sheltertech/time.rb
@@ -4,7 +4,7 @@ module ShelterTech
   module Time
     ## Convert time from hhmm format to number of minutes since midnight
     def self.hhmm_to_minutes(time)
-      (time / 100) * 60 + time % 60
+      (time / 100) * 60 + time % 100
     end
 
     ## Convert time from number of minutes since midnight to hhmm

--- a/spec/lib/sheltertech/time_spec.rb
+++ b/spec/lib/sheltertech/time_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ShelterTech::Time do
+  describe "hhmm_to_minutes" do
+    it "converts correctly" do
+      expect(ShelterTech::Time.hhmm_to_minutes(0)).to eq(0)
+      expect(ShelterTech::Time.hhmm_to_minutes(30)).to eq(30)
+      expect(ShelterTech::Time.hhmm_to_minutes(130)).to eq(90)
+      expect(ShelterTech::Time.hhmm_to_minutes(300)).to eq(180)
+      expect(ShelterTech::Time.hhmm_to_minutes(447)).to eq(287)
+    end
+  end
+
+  describe "minutes_to_hhmm" do
+    it "converts correctly" do
+      expect(ShelterTech::Time.minutes_to_hhmm(0)).to eq(0)
+      expect(ShelterTech::Time.minutes_to_hhmm(30)).to eq(30)
+      expect(ShelterTech::Time.minutes_to_hhmm(90)).to eq(130)
+      expect(ShelterTech::Time.minutes_to_hhmm(180)).to eq(300)
+      expect(ShelterTech::Time.minutes_to_hhmm(287)).to eq(447)
+    end
+  end
+end

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -3,5 +3,61 @@
 require 'rails_helper'
 
 RSpec.describe Schedule, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#round_time" do
+    before(:example) do
+      @schedule = build(:schedule)
+    end
+
+    it "rounds 0 to 0" do
+      expect(@schedule.send(:round_time, 0, 30, :down)).to eq(0)
+      expect(@schedule.send(:round_time, 0, 30, :up)).to eq(0)
+    end
+
+    it "rounds down properly" do
+      expect(@schedule.send(:round_time, 1, 15, :down)).to eq(0)
+      expect(@schedule.send(:round_time, 14, 15, :down)).to eq(0)
+      expect(@schedule.send(:round_time, 15, 15, :down)).to eq(15)
+    end
+
+    it "rounds up properly" do
+      expect(@schedule.send(:round_time, 1, 15, :up)).to eq(15)
+      expect(@schedule.send(:round_time, 14, 15, :up)).to eq(15)
+      expect(@schedule.send(:round_time, 15, 15, :up)).to eq(15)
+    end
+  end
+
+  describe "#format_algolia_open_time" do
+    it "formats properly" do
+      schedule = build(:schedule)
+      expect(schedule.send(:format_algolia_open_time, 'Tuesday', 945)).to eq('Tu-15:45')
+      expect(schedule.send(:format_algolia_open_time, 'Wednesday', 120)).to eq('W-2:00')
+      expect(schedule.send(:format_algolia_open_time, 'Sunday', 0)).to eq('Su-0:00')
+      expect(schedule.send(:format_algolia_open_time, 'Friday', 270)).to eq('F-4:30')
+    end
+  end
+
+  describe "#algolia_open_times" do
+    it "formats properly" do
+      schedule = build(:schedule, schedule_days: [
+                         build(:schedule_day, day: 'Thursday', opens_at: 1300, closes_at: 1400),
+                         build(:schedule_day, day: 'Wednesday', opens_at: 945, closes_at: 1515)
+                       ])
+      expect(schedule.algolia_open_times).to match_array(%w[
+                                                           W-9:30
+                                                           W-10:00
+                                                           W-10:30
+                                                           W-11:00
+                                                           W-11:30
+                                                           W-12:00
+                                                           W-12:30
+                                                           W-13:00
+                                                           W-13:30
+                                                           W-14:00
+                                                           W-14:30
+                                                           W-15:00
+                                                           Th-13:00
+                                                           Th-13:30
+                                                         ])
+    end
+  end
 end


### PR DESCRIPTION
Couldn't assign @cliffcrosland as a reviewer, but wanted to tag him on this.

This adds the `open_times` property to the Algolia index, as we discussed last night. I made sure to default Services to their associated Resource if the Service doesn't have a schedule. I also rounded open times down to the nearest half hour and close times up in order to err on the side of showing things that may just be outside of open hours.

@twolfe2, note that I picked the following abbreviations for the days, just to make sure we're both consistent: M, Tu, W, Th, F, Sa, Su.

Here's a screenshot of the new property on Algolia:

<img width="427" alt="screen shot 2018-11-15 at 8 14 50 am" src="https://user-images.githubusercontent.com/1002748/48566203-112eca00-e8af-11e8-87f8-c9511428cffe.png">

I would like to add some unit tests for this, which I could write in RSpec, but I don't have time right now, so we could probably merge this first before I write the tests so that @twolfe2 can start working against it.