### PR TITLE
Handle nil times when building Algolia index.

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -11,16 +11,7 @@ class Schedule < ActiveRecord::Base
 
   # Format open times for use in Algolia index e.g. "M-8:00"
   def algolia_open_times
-    block_size = 30
-    schedule_days.flat_map do |day|
-      opens_at_minutes = ShelterTech::Time.hhmm_to_minutes(day.opens_at)
-      closes_at_minutes = ShelterTech::Time.hhmm_to_minutes(day.closes_at)
-      opens_at = round_time(opens_at_minutes, block_size, :down)
-      closes_at = round_time(closes_at_minutes, block_size, :up)
-      (opens_at...closes_at).step(block_size).map do |time|
-        format_algolia_open_time(day.day, time)
-      end
-    end
+    schedule_days.flat_map(&method(:algolia_open_times_for_schedule_day))
   end
 
   private
@@ -36,6 +27,19 @@ class Schedule < ActiveRecord::Base
       ((minutes - 1) / block_size + 1) * block_size
     else
       raise ArgumentError, "Invalid rounding direction: #{direction}"
+    end
+  end
+
+  def algolia_open_times_for_schedule_day(day)
+    return [] if day.opens_at.nil? || day.closes_at.nil?
+
+    block_size = 30
+    opens_at_minutes = ShelterTech::Time.hhmm_to_minutes(day.opens_at)
+    closes_at_minutes = ShelterTech::Time.hhmm_to_minutes(day.closes_at)
+    opens_at = round_time(opens_at_minutes, block_size, :down)
+    closes_at = round_time(closes_at_minutes, block_size, :up)
+    (opens_at...closes_at).step(block_size).map do |time|
+      format_algolia_open_time(day.day, time)
     end
   end
 

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -59,5 +59,14 @@ RSpec.describe Schedule, type: :model do
                                                            Th-13:30
                                                          ])
     end
+
+    it "handles nil times properly" do
+      schedule = build(:schedule, schedule_days: [
+                         build(:schedule_day, day: 'Thursday', opens_at: nil, closes_at: 1400),
+                         build(:schedule_day, day: 'Wednesday', opens_at: 945, closes_at: nil),
+                         build(:schedule_day, day: 'Friday', opens_at: 900, closes_at: 930)
+                       ])
+      expect(schedule.algolia_open_times).to match_array(%w[F-9:00])
+    end
   end
 end


### PR DESCRIPTION
Fixes https://sentry.io/sheltertech/askdarcel-api/issues/768554744/

It looks like it's possible for a `ScheduleDay` to have a `nil` `opens_at` or `closes_at`, so we were seeing errors in staging where an exception gets thrown when we don't properly handle `nil`. This adds a guard to prevent an exception from being thrown if a `nil` value is encountered.

I added an RSpec test to capture this case.