### PR TITLE
Add open_times to list of attributes for faceting.

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -34,7 +34,7 @@ class Resource < ActiveRecord::Base
     # Important: Use Resource.reindex! and Service.reindex! to reindex/create your index
     algoliasearch index_name: "#{Rails.configuration.x.algolia.index_prefix}_services_search", id: :algolia_id do # rubocop:disable Metrics/BlockLength,Metrics/LineLength
       # specify the list of attributes available for faceting
-      attributesForFaceting [:categories]
+      attributesForFaceting %i[categories open_times]
       # Define attributes used to build an Algolia record
       add_attribute :_geoloc do
         { lat: address_latitude.to_f, lng: address_longitude.to_f }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -27,7 +27,7 @@ class Service < ActiveRecord::Base
     # and staging servers use the same RAILS_ENV.
     algoliasearch index_name: "#{Rails.configuration.x.algolia.index_prefix}_services_search", id: :algolia_id do # rubocop:disable Metrics/BlockLength,Metrics/LineLength
       # specify the list of attributes available for faceting
-      attributesForFaceting [:categories]
+      attributesForFaceting %i[categories open_times]
 
       # Define attributes used to build an Algolia record
       add_attribute :status


### PR DESCRIPTION
Part of the reason that the Open Now filter doesn't work on the frontend is because the `open_times` attribute needs to be added as an ["attribute for faceting"](https://www.algolia.com/doc/guides/searching/filtering/?language=javascript#how-to-format-your-data-to-be-used-as-filters), which is apparently something that is mandatory for filtering on string fields.

I still need to make some frontend changes, but this can go in sooner. We'll want to do a full reindex after this is merged in.