### PR TITLE
Add scheduled job for Algolia reindexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,11 @@ gem 'lograge'
 
 gem 'prometheus-client'
 
+# Background Job Processing
+gem 'daemons'
+gem 'delayed_job_active_record'
+gem 'whenever', require: false
+
 group :production do
   gem 'activerecord-nulldb-adapter'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,8 +54,15 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11.0)
     byebug (10.0.2)
+    chronic (0.10.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
+    daemons (1.2.6)
+    delayed_job (4.1.5)
+      activesupport (>= 3.0, < 5.3)
+    delayed_job_active_record (4.1.3)
+      activerecord (>= 3.0, < 5.3)
+      delayed_job (>= 3.0, < 5)
     devise (4.4.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -208,6 +215,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.10.0)
+      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
@@ -217,6 +226,8 @@ DEPENDENCIES
   algoliasearch-rails
   bullet
   byebug
+  daemons
+  delayed_job_active_record
   devise_token_auth
   dotenv-rails
   factory_bot_rails
@@ -236,6 +247,7 @@ DEPENDENCIES
   rubocop
   sentry-raven
   spring
+  whenever
 
 BUNDLED WITH
    1.16.6

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ $ docker-compose build
 # Start the database container (in the background with -d)
 $ docker-compose up -d db
 
+# Start the worker container (in the background with -d)
+$ docker-compose up -d worker
+
 # Generate random database fixtures
 $ docker-compose run --rm api rake db:setup db:populate
 
@@ -111,7 +114,13 @@ After cloning the repository and `cd`ing into the workspace:
   Alternatively, you can generate random fixtures:
   - `rake db:setup db:populate`
 
-6. Run the development server.
+6. (Optional) Run the background job worker.
+  - To run a worker to continuously process background jobs:
+    - `rake jobs:work`
+  - To run a worker to process all existing background jobs and exit:
+    - `rake jobs:workoff`
+
+7. Run the development server.
   - `rails s -b 0.0.0.0`
-7. Do NOT do sudo install -rails
+8. Do NOT do sudo install -rails
 

--- a/app/jobs/algolia_reindex_job.rb
+++ b/app/jobs/algolia_reindex_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Background job to reindex all relevant database records in Algolia.
+#
+# Usage:
+#
+# To send job to a background worker to execute:
+#
+# > AlgoliaReindexJob.perform_async
+#
+# To execute in-line immediately from Rails console:
+#
+# > AlgoliaReindexJob.new.perform
+#
+class AlgoliaReindexJob
+  def self.perform_async
+    Delayed::Job.enqueue(AlgoliaReindexJob.new)
+  end
+
+  def perform
+    Resource.where(status: :approved).reindex
+    # Since Service and Resource share an algolia index, we use `reindex!` so
+    # Service reindexing does not clear out Resource index records.
+    Service.where(status: :approved).reindex!
+  end
+end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/bin/worker_restart.sh
+++ b/bin/worker_restart.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Use whenever gem to update crontab from config/schedule.rb
+whenever --update-crontab
+
+# Restart delayed_job worker process
+./bin/delayed_job restart

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,7 @@ module AskdarcelApi
         ActiveRecord::Migrator.migrate "db/migrate"
       end
     end
+
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+# Reindex all records in Algolia every day.
+every 1.hour do
+  runner 'AlgoliaReindexJob.perform_async'
+end

--- a/db/migrate/20181127163326_create_delayed_jobs.rb
+++ b/db/migrate/20181127163326_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.0]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180805190627) do
+ActiveRecord::Schema.define(version: 20181127163326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,6 +117,21 @@ ActiveRecord::Schema.define(version: 20180805190627) do
     t.integer  "service_id"
     t.index ["resource_id"], name: "index_contacts_on_resource_id", using: :btree
     t.index ["service_id"], name: "index_contacts_on_service_id", using: :btree
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 
   create_table "eligibilities", force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,28 @@
 version: "3.5"
+
+# Common configuration for Rails processes.
+x-rails-common:
+  &rails-common
+  build:
+    context: .
+    dockerfile: Dockerfile.dev
+  depends_on:
+    - db
+  environment:
+    DATABASE_URL: postgres://postgres@db/askdarcel_development
+    TEST_DATABASE_URL: postgres://postgres@db/askdarcel_test
+    ALGOLIA_APPLICATION_ID:
+    ALGOLIA_API_KEY:
+    ALGOLIA_INDEX_PREFIX:
+  networks:
+    - askdarcel
+  volumes:
+    - .:/usr/src/app
+    # Avoid leftover server.pid files when container exits.
+    # https://auth0.com/blog/ruby-on-rails-killer-workflow-with-docker-part-1/
+    - type: tmpfs
+      target: /usr/src/app/tmp/pids
+
 services:
   db:
     image: "postgres:9.5"
@@ -6,28 +30,14 @@ services:
       - askdarcel
 
   api:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    << : *rails-common
     command: rails server --port=3000 --binding=0.0.0.0
-    depends_on:
-      - db
-    environment:
-      DATABASE_URL: postgres://postgres@db/askdarcel_development
-      TEST_DATABASE_URL: postgres://postgres@db/askdarcel_test
-      ALGOLIA_APPLICATION_ID:
-      ALGOLIA_API_KEY:
-      ALGOLIA_INDEX_PREFIX:
-    networks:
-      - askdarcel
     ports:
       - "3000:3000"
-    volumes:
-      - .:/usr/src/app
-      # Avoid leftover server.pid files when container exits.
-      # https://auth0.com/blog/ruby-on-rails-killer-workflow-with-docker-part-1/
-      - type: tmpfs
-        target: /usr/src/app/tmp/pids
+
+  worker:
+    << : *rails-common
+    command: rake jobs:work
 
   postman:
     build:

--- a/lib/tasks/algolia.rake
+++ b/lib/tasks/algolia.rake
@@ -3,8 +3,7 @@
 namespace :algolia do
   task reindex: :environment do
     print "Reindexing resource/service index... "
-    Resource.where(status: :approved).reindex
-    Service.where(status: :approved).reindex!
+    AlgoliaReindexJob.new.perform
     puts "success."
   end
 end

--- a/spec/jobs/algolia_reindex_job_spec.rb
+++ b/spec/jobs/algolia_reindex_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Algolia Reindex Job' do
+  context 'when scheduling a reindex job' do
+    it 'enqueues a new background job properly' do
+      expect(Delayed::Job.all).to be_empty
+
+      AlgoliaReindexJob.perform_async
+
+      expect(Delayed::Job.count).to eq(1)
+      delayed_job = Delayed::Job.first
+      expect(delayed_job.handler).to include('AlgoliaReindexJob')
+    end
+  end
+
+  context 'when executing a reindex job' do
+    it 'runs Algolia reindex operation on the expected models' do
+      resource_query = double
+      expect(Resource).to receive(:where).with(status: :approved).and_return(resource_query)
+      expect(resource_query).to receive(:reindex)
+
+      service_query = double
+      expect(Service).to receive(:where).with(status: :approved).and_return(service_query)
+      expect(service_query).to receive(:reindex!)
+
+      AlgoliaReindexJob.new.perform
+    end
+  end
+end


### PR DESCRIPTION
Use `whenever` gem to schedule an Algolia reindex job every hour.

Use `delayed_job` gem to run a worker to continuously process background
jobs, including this Algolia reindex job.