### PR TITLE
Add API endpoint for featured eligibilities

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -9,7 +9,7 @@ class ChangeRequestsController < ApplicationController
   rescue ActiveRecord::UnknownAttributeError => e
     render status: :bad_request, json: unknown_attribute_error_json(e)
   rescue ActiveRecord::RecordInvalid => e
-    render status: :bad_request, json: record_invalid_error_json(e)
+    render status: :bad_request, json: RecordInvalidPresenter.present(e)
   end
 
   def create_change_request
@@ -278,14 +278,5 @@ class ChangeRequestsController < ApplicationController
   # safe to return in a JSON API response.
   def unknown_attribute_error_json(error)
     { error: "Unknown attribute in request: \"#{error.attribute}\"" }
-  end
-
-  # Given an ActiveRecord::RecordInvalid error, returns a hash that would be
-  # safe to return in a JSON API response.
-  def record_invalid_error_json(error)
-    msgs = error.record.errors.messages.map do |field, validation_error|
-      "#{field} #{validation_error}"
-    end
-    { error: "Validation errors: #{msgs.join(', ')}" }
   end
 end

--- a/app/controllers/eligibilities_controller.rb
+++ b/app/controllers/eligibilities_controller.rb
@@ -1,9 +1,70 @@
 # frozen_string_literal: true
 
 class EligibilitiesController < ApplicationController
+  # GET /eligibilities
+  #
+  # Return all eligibilities sorted by name in ascending order.
   def index
     eligibilities = Eligibility.order(:name)
 
     render json: EligibilityPresenter.present(eligibilities)
+  end
+
+  # GET /eligibilities/:id
+  #
+  # @param :id [ Integer ] id of eligibility to show
+  def show
+    eligibility = Eligibility.find(params[:id])
+
+    render json: EligibilityPresenter.present(eligibility)
+  rescue ActiveRecord::RecordNotFound => e
+    render status: :not_found, json: { error: e.message }
+  end
+
+  # PUT /eligibilities/:id
+  #
+  # @param :id [ Integer ] id of eligibility to update
+  # @param :name [ String, Optional ] new name for this eligibility
+  # @param :feature_rank [ Integer or nil, Optional ] new feature_rank for this
+  # eligibility.
+  def update
+    eligibility = Eligibility.find(params[:id])
+
+    eligibility.update!(params.permit(:name, :feature_rank))
+
+    render json: EligibilityPresenter.present(eligibility)
+  rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordNotUnique,
+         ActiveRecord::RecordInvalid => e
+    render_update_error(e)
+  end
+
+  # GET /eligibilities/featured
+  #
+  # Returns featured eligibilities sorted by `feature_rank`. In addition,
+  # returns the number of resources associated with each eligibility.
+  def featured
+    eligibilities = Eligibility.order(:feature_rank).where.not(feature_rank: nil).to_a
+    resource_counts = Eligibilities::ResourceCounts.compute(eligibilities.map(&:id))
+    items = EligibilityPresenter.present(eligibilities)
+    items.each do |item|
+      item['resource_count'] = resource_counts[item['id']]
+    end
+
+    render json: { eligibilities: items }
+  end
+
+  private
+
+  def render_update_error(error)
+    if error.is_a?(ActiveRecord::RecordNotFound)
+      render status: :not_found, json: { error: error.message }
+    elsif error.is_a?(ActiveRecord::RecordNotUnique)
+      error_msg = "Eligibility with name #{params[:name]} already exists"
+      render status: :bad_request, json: { error: error_msg }
+    elsif error.is_a?(ActiveRecord::RecordInvalid)
+      render status: :bad_request, json: RecordInvalidPresenter.present(error)
+    else
+      render status: :internal_server_error, json: { error: 'Internal server error' }
+    end
   end
 end

--- a/app/models/eligibilities_service.rb
+++ b/app/models/eligibilities_service.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class EligibilitiesService < ApplicationRecord
+  belongs_to :eligibilities
+  belongs_to :services
+end

--- a/app/models/eligibility.rb
+++ b/app/models/eligibility.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# Schema description:
+#
+# name [ String ] Name of the eligibility, eg. "Veterans". Must be present and
+# unique.
+#
+# feature_rank [ Integer or nil ] If present, will be featured on the landing
+# page. Featured eligibilities on the landing page are sorted by feature_rank
+# in ascending order.
+#
+# created_at [ DateTime ] when created
+#
+# updated_at [ DateTime ] when last updated
+#
 class Eligibility < ApplicationRecord
   has_and_belongs_to_many :services
+
+  validates :name, presence: true
 end

--- a/app/presenters/eligibility_presenter.rb
+++ b/app/presenters/eligibility_presenter.rb
@@ -3,4 +3,5 @@
 class EligibilityPresenter < Jsonite
   property :name
   property :id
+  property :feature_rank
 end

--- a/app/presenters/record_invalid_presenter.rb
+++ b/app/presenters/record_invalid_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Presents ActiveRecord::RecordInvalid error objects.
+#
+# Example output:
+#
+# { error: "Validation errors: Name is required, Rank is required" }
+class RecordInvalidPresenter < Jsonite
+  let(:error) do
+    msgs = record.errors.messages.map do |field, validation_error|
+      "#{field} (#{validation_error.join(', ')})"
+    end
+    "Validation errors: #{msgs.join(', ')}"
+  end
+
+  property :error
+end

--- a/app/services/eligibilities/resource_counts.rb
+++ b/app/services/eligibilities/resource_counts.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Eligibilities
+  module ResourceCounts
+    # Given a list of eligibility ids, return a map from eligibility id to number
+    # of resources associated with that eligibility.
+    #
+    # Performance note: For efficiency, this method only executes two SQL
+    # queries. It relies on the assumption that the number of associations
+    # between eligibilities and resources is small enough to fit in memory easily
+    # (i.e. on the order of 100s).
+    #
+    # @param :eligibility_ids [ Array<Integer> ] array of eligibility ids
+    # @return [ Hash ] map whose keys are eligibility ids and whose values are
+    # the number of resources associated with the eligibility
+    def self.compute(eligibility_ids)
+      # Compute map from eligibility_id to set of service_ids
+      pairs = EligibilitiesService.where(eligibility_id: eligibility_ids).pluck(:eligibility_id, :service_id)
+      eligibility_to_services = compute_eligibility_to_services(pairs)
+      service_ids = pairs.map(&:last).uniq
+
+      # Compute map from service_id to resource_id
+      service_to_resource = Service.where(id: service_ids).pluck(:id, :resource_id).to_h
+
+      # Using two maps above, compute map from eligibility_id to set of resource_ids
+      eligibility_to_resources = compute_eligibility_to_resources(eligibility_to_services, service_to_resource)
+
+      # Compute map from eligibility to resource_id count
+      eligibility_to_resources.map do |eligibility_id, resource_ids|
+        [eligibility_id, resource_ids.size]
+      end.to_h
+    end
+
+    # Given a list of [eligibility_id, service_id] pairs, compute a hash that
+    # maps from eligibility_id to set of service_ids.
+    def self.compute_eligibility_to_services(eligibility_service_pairs)
+      ret = Hash.new { |h, k| h[k] = Set.new }
+      eligibility_service_pairs.each do |eligibility_id, service_id|
+        ret[eligibility_id] << service_id
+      end
+      ret
+    end
+
+    private_class_method :compute_eligibility_to_services
+
+    # Using the relationships in these hashes:
+    # - map from eligibility_id to set of service_ids
+    # - map from service_id to resource_id
+    # return hash that maps from eligibility_id to set of resource_ids.
+    def self.compute_eligibility_to_resources(eligibility_to_services, service_to_resource)
+      ret = Hash.new { |h, k| h[k] = Set.new }
+      eligibility_to_services.each do |eligibility_id, service_ids|
+        service_ids.each do |service_id|
+          resource_id = service_to_resource[service_id]
+          next if resource_id.nil?
+
+          ret[eligibility_id] << resource_id
+        end
+      end
+      ret
+    end
+
+    private_class_method :compute_eligibility_to_resources
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,11 @@ Rails.application.routes.draw do
       get :counts
     end
   end
-  resources :eligibilities
+  resources :eligibilities, only: %i[index show update] do
+    collection do
+      get :featured
+    end
+  end
   resources :resources do
     resources :notes, only: :create
     collection do

--- a/db/migrate/20181231212751_add_feature_rank_to_eligibilities.rb
+++ b/db/migrate/20181231212751_add_feature_rank_to_eligibilities.rb
@@ -1,0 +1,12 @@
+class AddFeatureRankToEligibilities < ActiveRecord::Migration[5.0]
+  def change
+    add_column :eligibilities, :feature_rank, :integer
+
+    # to return eligibilities sorted by feature_rank
+    add_index :eligibilities, :feature_rank
+
+    # for efficient lookup in join table
+    add_index :eligibilities_services, :eligibility_id
+    add_index :eligibilities_services, :service_id
+  end
+end

--- a/db/migrate/20190106233415_add_unique_name_index_to_eligibilities.rb
+++ b/db/migrate/20190106233415_add_unique_name_index_to_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddUniqueNameIndexToEligibilities < ActiveRecord::Migration[5.0]
+  def change
+    add_index :eligibilities, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181127163326) do
+ActiveRecord::Schema.define(version: 20190106233415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -136,13 +136,18 @@ ActiveRecord::Schema.define(version: 20181127163326) do
 
   create_table "eligibilities", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.integer  "feature_rank"
+    t.index ["feature_rank"], name: "index_eligibilities_on_feature_rank", using: :btree
+    t.index ["name"], name: "index_eligibilities_on_name", unique: true, using: :btree
   end
 
   create_table "eligibilities_services", id: false, force: :cascade do |t|
     t.integer "service_id",     null: false
     t.integer "eligibility_id", null: false
+    t.index ["eligibility_id"], name: "index_eligibilities_services_on_eligibility_id", using: :btree
+    t.index ["service_id"], name: "index_eligibilities_services_on_service_id", using: :btree
   end
 
   create_table "field_changes", force: :cascade do |t|

--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -327,7 +327,12 @@
 							"",
 							"tests[\"Status code is 200\"] = responseCode.code === 200;",
 							"",
-							""
+							"pm.test(\"Eligibilities are correctly sorted\", function () {",
+							"  var jsonData = pm.response.json();",
+							"  pm.expect(jsonData.eligibilities.length).to.eql(10);",
+							"  pm.expect(jsonData.eligibilities[0].name).to.eql('Alzheimers');",
+							"  pm.expect(jsonData.eligibilities[9].name).to.eql('Veterans');",
+							"});"
 						]
 					}
 				}
@@ -351,6 +356,159 @@
 					],
 					"path": [
 						"eligibilities"
+					]
+				}
+			},
+			"response": []
+		},
+    {
+			"name": "Get featured eligibilities",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "76d9f301-73fd-4fc4-870d-47060c278e49",
+						"exec": [
+							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"",
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"",
+							"pm.test(\"Featured eligibilities are correctly sorted by feature_rank\", function () {",
+							"  var jsonData = pm.response.json();",
+							"  pm.expect(jsonData.eligibilities.length).to.eql(6);",
+							"  pm.expect(jsonData.eligibilities[0].name).to.eql('Seniors');",
+							"  pm.expect(jsonData.eligibilities[0].feature_rank).to.eql(1);",
+							"  pm.expect(jsonData.eligibilities[0].resource_count).to.eql(24);",
+							"  pm.expect(jsonData.eligibilities[5].name).to.eql('Immigrants');",
+							"  pm.expect(jsonData.eligibilities[5].feature_rank).to.eql(6);",
+							"  pm.expect(jsonData.eligibilities[5].resource_count).to.eql(8);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{base_url}}/eligibilities/featured",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"eligibilities",
+						"featured"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Update eligibility feature_rank, 1 of 2",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5c9b01e5-fe7c-48aa-88d8-2240f871bd05",
+						"exec": [
+							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"",
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"",
+							"pm.test(\"Eligibility feature_rank now 2\", function () {",
+							"  var jsonData = pm.response.json();",
+							"  pm.expect(jsonData.eligibility.name).to.eql(\"Seniors\");",
+							"  pm.expect(jsonData.eligibility.feature_rank).to.eql(2);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"feature_rank\": 2\n}"
+				},
+				"url": {
+					"raw": "{{base_url}}/eligibilities/1",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"eligibilities",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Update eligibility feature_rank, 2 of 2",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5c9b01e5-fe7c-48aa-88d8-2240f871bd05",
+						"exec": [
+							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"",
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"",
+							"pm.test(\"Eligibility feature_rank now back to 1\", function () {",
+							"  var jsonData = pm.response.json();",
+							"  pm.expect(jsonData.eligibility.name).to.eql(\"Seniors\");",
+							"  pm.expect(jsonData.eligibility.feature_rank).to.eql(1);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Accept",
+						"type": "text",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"feature_rank\": 1\n}"
+				},
+				"url": {
+					"raw": "{{base_url}}/eligibilities/1",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"eligibilities",
+						"1"
 					]
 				}
 			},

--- a/spec/factories/eligibilities.rb
+++ b/spec/factories/eligibilities.rb
@@ -2,5 +2,7 @@
 
 FactoryBot.define do
   factory :eligibility do
+    # 'eligibility-a', 'eligibility-b', etc.
+    sequence(:name, 'a') { |n| "eligibility-#{n}" }
   end
 end

--- a/spec/requests/eligibilities_spec.rb
+++ b/spec/requests/eligibilities_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Eligibilities' do
+  context 'index' do
+    let!(:eligibilities) { create_list :eligibility, 3 }
+
+    it 'returns all eligibilities ordered by name' do
+      get '/eligibilities'
+
+      expect(response).to be_ok
+      items = response_json['eligibilities']
+      expect(items.size).to eq(3)
+      names = items.map { |item| item['name'] }
+      expect(names).to eq(names.sort)
+    end
+  end
+
+  context 'show' do
+    let!(:eligibility) { create(:eligibility, name: 'Veterans') }
+
+    context 'when record exists' do
+      it 'returns eligibility successfully' do
+        get "/eligibilities/#{eligibility.id}"
+
+        expect(response).to be_ok
+        item = response_json['eligibility']
+        expect(item['id']).to eq(eligibility.id)
+        expect(item['name']).to eq('Veterans')
+      end
+    end
+
+    context 'when record does not exist' do
+      let(:not_found_id) { Eligibility.maximum(:id) + 1 }
+
+      it 'returns not found' do
+        get "/eligibilities/#{not_found_id}"
+
+        expect(response).to be_not_found
+        expected_error_msg = "Couldn't find Eligibility with 'id'=#{not_found_id}"
+        expect(response_json['error']).to include(expected_error_msg)
+      end
+    end
+  end
+
+  context 'update' do
+    let!(:eligibility) { create(:eligibility, name: 'Senior') }
+
+    context 'when update is valid' do
+      it 'updates successfully' do
+        put "/eligibilities/#{eligibility.id}", params: { name: 'Seniors', feature_rank: 3 }
+
+        expect(response).to be_ok
+        item = response_json['eligibility']
+        expect(item['id']).to eq(eligibility.id)
+        expect(item['name']).to eq('Seniors')
+        expect(item['feature_rank']).to eq(3)
+      end
+    end
+
+    context 'when name params is invalid' do
+      it 'returns bad request response' do
+        put "/eligibilities/#{eligibility.id}", params: { name: nil, feature_rank: 3 }
+
+        expect(response).to be_bad_request
+        expect(response_json['error']).to include('Validation errors: name')
+        expect(response_json['error']).to include("can't be blank")
+      end
+    end
+
+    context 'when updating feature_rank alone' do
+      it 'updates successfully' do
+        put "/eligibilities/#{eligibility.id}", params: { feature_rank: 1 }
+
+        expect(response).to be_ok
+        item = response_json['eligibility']
+        expect(item['id']).to eq(eligibility.id)
+        expect(item['name']).to eq(eligibility.name)
+        expect(item['feature_rank']).to eq(1)
+      end
+    end
+
+    context 'when updating a record that is not found' do
+      let(:not_found_id) { Eligibility.maximum(:id) + 1 }
+
+      it 'returns bad request response' do
+        put "/eligibilities/#{not_found_id}", params: { feature_rank: 1 }
+
+        expect(response).to be_not_found
+        expected_error_msg = "Couldn't find Eligibility with 'id'=#{not_found_id}"
+        expect(response_json['error']).to include(expected_error_msg)
+      end
+    end
+
+    context 'when updating name to another value that already exists in table' do
+      let!(:other_eligibility) { create(:eligibility, name: 'Veterans') }
+
+      it 'returns bad request response' do
+        put "/eligibilities/#{eligibility.id}", params: { name: other_eligibility.name }
+
+        expect(response).to be_bad_request
+        expect(response_json['error']).to include('Eligibility with name')
+        expect(response_json['error']).to include('already exists')
+      end
+    end
+  end
+
+  context 'featured' do
+    let!(:eligibilities) { create_list :eligibility, 3 }
+
+    before do
+      # e1 and e2 are featured, but not e3.
+      # e2 has highest rank.
+      e1, e2 = eligibilities[0..1]
+      e1.update(feature_rank: 2)
+      e2.update(feature_rank: 1)
+
+      # e2 is associated with 2 resources
+      2.times { e2.services << create(:service, resource: create(:resource)) }
+      # e1 is associated with 1 resource
+      e1.services << create(:service, resource: create(:resource))
+    end
+
+    it 'returns all featured eligibilities, ordered by feature_rank, along with resource counts' do
+      get '/eligibilities/featured'
+
+      expect(response).to be_ok
+      items = response_json['eligibilities']
+      expect(items.size).to eq(2)
+
+      e1, e2 = eligibilities[0..1]
+      expect(items[0]['id']).to eq(e2.id)
+      expect(items[0]['resource_count']).to eq(2)
+      expect(items[1]['id']).to eq(e1.id)
+      expect(items[1]['resource_count']).to eq(1)
+    end
+  end
+end

--- a/spec/services/eligibilities/resource_counts_spec.rb
+++ b/spec/services/eligibilities/resource_counts_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Eligibilities::ResourceCounts, type: :model do
+  describe 'computing resource counts' do
+    let!(:eligibilities) { create_list :eligibility, 4 }
+    let!(:resources) { create_list(:resource, 3) }
+    let!(:services) do
+      services = []
+      resources.each do |resource|
+        services += Array.new(2) { create :service, resource: resource }
+        resource.reload
+      end
+      services
+    end
+
+    before do
+      # eligibility 1 associated with all 3 resources
+      e1 = eligibilities[0]
+      resources.each do |resource|
+        resource.services.each { |s| e1.services << s }
+      end
+
+      # eligibility 2 associated with first 2 resources
+      e2 = eligibilities[1]
+      resources.take(2).each do |resource|
+        resource.services.each { |s| e2.services << s }
+      end
+
+      # eligibility 3 and 4 associated with only first resource
+      e3, e4 = eligibilities[2..-1]
+      resources.take(1).each do |resource|
+        resource.services.each { |s| e3.services << s }
+        resource.services.each { |s| e4.services << s }
+      end
+    end
+
+    it 'computes the map from eligibility id to resource count correctly' do
+      eligibility_ids = eligibilities.map(&:id)
+
+      result = described_class.compute(eligibility_ids)
+
+      e1, e2, e3, e4 = eligibilities
+      expect(result.is_a?(Hash)).to be true
+      expect(result[e1.id]).to eq(3)
+      expect(result[e2.id]).to eq(2)
+      expect(result[e3.id]).to eq(1)
+      expect(result[e4.id]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
- Add a new column, `feature_rank`, to the eligibilities table
- Introduce a new API endpoint, `/eligibilities/featured`, that returns:
  - eligibilities to feature on the landing page, sorted by
    `feature_rank`
  - the number of resources associated with each eligibility

Implementation of https://github.com/ShelterTechSF/askdarcel-api/issues/369