### PR TITLE
370 add find all resources endpoint

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -4,19 +4,8 @@ class ResourcesController < ApplicationController
   def index
     category_id = params.require :category_id
 
-    if category_id == "all"
-      relation = resources.where(status: Resource.statuses[:approved])
-      render json: ResourcesPresenter.present(relation)
-    else   
-      # TODO: This can be simplified once we remove categories from resources
-      relation =
-        resources
-        .joins(:address)
-        .where(categories_join_string, category_id, category_id)
-        .where(status: Resource.statuses[:approved])
-        .order(sort_order)
-      render json: ResourcesPresenter.present(relation)
-    end
+    relation = get_all_resources(category_id)
+    render json: ResourcesPresenter.present(relation)
   end
 
   def show
@@ -64,6 +53,20 @@ class ResourcesController < ApplicationController
   end
 
   private
+
+  def get_all_resources(category_id)
+    relation = if category_id == "all"
+                 resources.where(status: Resource.statuses[:approved])
+               else
+                 # TODO: This can be simplified once we remove categories from resources
+                 resources
+                   .joins(:address)
+                   .where(categories_join_string, category_id, category_id)
+                   .where(status: Resource.statuses[:approved])
+                   .order(sort_order)
+               end
+    relation
+  end
 
   # Clean raw request params for interoperability with Rails APIs.
   def clean_resources_params

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -3,14 +3,20 @@
 class ResourcesController < ApplicationController
   def index
     category_id = params.require :category_id
-    # TODO: This can be simplified once we remove categories from resources
-    relation =
-      resources
-      .joins(:address)
-      .where(categories_join_string, category_id, category_id)
-      .where(status: Resource.statuses[:approved])
-      .order(sort_order)
-    render json: ResourcesPresenter.present(relation)
+
+    if category_id == "all"
+      relation = resources.where(status: Resource.statuses[:approved])
+      render json: ResourcesPresenter.present(relation)
+    else   
+      # TODO: This can be simplified once we remove categories from resources
+      relation =
+        resources
+        .joins(:address)
+        .where(categories_join_string, category_id, category_id)
+        .where(status: Resource.statuses[:approved])
+        .order(sort_order)
+      render json: ResourcesPresenter.present(relation)
+    end
   end
 
   def show

--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "2b5a5078-9637-4ee2-83e5-5727261921cd",
+		"_postman_id": "03c5a084-2528-4d6f-92fa-17a58b0780af",
 		"name": "AskDarcel API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -11,11 +11,10 @@
 				{
 					"listen": "test",
 					"script": {
+						"id": "6fc54ef1-1409-44a3-bc1e-6012a857e7dc",
 						"type": "text/javascript",
 						"exec": [
-							"tests[\"Response time is less than 200ms\"] = responseTime < 200;",
-							"",
-							"tests[\"Status code is 400\"] = responseCode.code === 400;  // category_id param is required"
+							"tests[\"Status code is 200\"] = responseCode.code === 200;  "
 						]
 					}
 				}
@@ -33,12 +32,18 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "{{base_url}}/resources",
+					"raw": "{{base_url}}/resources?category_id=all",
 					"host": [
 						"{{base_url}}"
 					],
 					"path": [
 						"resources"
+					],
+					"query": [
+						{
+							"key": "category_id",
+							"value": "all"
+						}
 					]
 				}
 			},


### PR DESCRIPTION
Enabled find all resources endpoint. Requires a category id of "all" to be passed in -- this is to prevent people from accidentally retrieving all resources by passing in a get with no parameters, as it is an  expensive operation.