### PR TITLE
[Work in Progress] Show featured eligibility service count

### DIFF
--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -486,9 +486,11 @@
 							"  pm.expect(jsonData.eligibilities[0].name).to.eql('Seniors');",
 							"  pm.expect(jsonData.eligibilities[0].feature_rank).to.eql(1);",
 							"  pm.expect(jsonData.eligibilities[0].resource_count).to.eql(24);",
+							"  pm.expect(jsonData.eligibilities[0].service_count).to.eql(24);",
 							"  pm.expect(jsonData.eligibilities[5].name).to.eql('Immigrants');",
 							"  pm.expect(jsonData.eligibilities[5].feature_rank).to.eql(6);",
 							"  pm.expect(jsonData.eligibilities[5].resource_count).to.eql(8);",
+							"  pm.expect(jsonData.eligibilities[5].service_count).to.eql(8);",
 							"});"
 						],
 						"type": "text/javascript"

--- a/spec/requests/eligibilities_spec.rb
+++ b/spec/requests/eligibilities_spec.rb
@@ -129,10 +129,13 @@ RSpec.describe 'Eligibilities' do
       items = response_json['eligibilities']
       expect(items.size).to eq(2)
 
+      # TODO(cliff): deprecate resource_count field
       e1, e2 = eligibilities[0..1]
       expect(items[0]['id']).to eq(e2.id)
+      expect(items[0]['service_count']).to eq(2)
       expect(items[0]['resource_count']).to eq(2)
       expect(items[1]['id']).to eq(e1.id)
+      expect(items[1]['service_count']).to eq(1)
       expect(items[1]['resource_count']).to eq(1)
     end
   end


### PR DESCRIPTION
Each item returned from the `eligibilities/featured` API endpoint now
contains a `service_count` value. This more closely matches the number
of search results that the user will see when they click on a featured
eligibility.