### PR TITLE
399 improve open and close times

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -118,7 +118,7 @@ class ResourcesController < ApplicationController
       :email,
       :status,
       address: %i[address_1 address_2 address_3 address_4 city state_province country postal_code latitude longitude],
-      schedule: [{ schedule_days: %i[day opens_at closes_at] }],
+      schedule: [{ schedule_days: %i[day opens_at closes_at open_day open_time close_day close_time] }],
       phones: %i[number service_type],
       notes: [:note],
       categories: [:id]

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -135,7 +135,7 @@ class ServicesController < ApplicationController
       :required_documents,
       :url,
       :wait_time,
-      schedule: [{ schedule_days: %i[day opens_at closes_at] }],
+      schedule: [{ schedule_days: %i[day opens_at closes_at open_time open_day close_time close_day] }],
       notes: [:note],
       categories: [:id],
       addresses: %i[id address_1 city state_province postal_code country],

--- a/app/presenters/schedule_days_presenter.rb
+++ b/app/presenters/schedule_days_presenter.rb
@@ -5,4 +5,16 @@ class ScheduleDaysPresenter < Jsonite
   property :day
   property :opens_at
   property :closes_at
+  property (:open_time) do
+  	if (open_time)
+      open_time.strftime('%H:%M:%S')
+    end
+  end
+  property :open_day
+  property (:close_time) do
+  	if (close_time)
+      close_time.strftime('%H:%M:%S')
+    end
+  end
+  property :close_day
 end

--- a/app/presenters/schedule_days_presenter.rb
+++ b/app/presenters/schedule_days_presenter.rb
@@ -5,16 +5,12 @@ class ScheduleDaysPresenter < Jsonite
   property :day
   property :opens_at
   property :closes_at
-  property (:open_time) do
-  	if (open_time)
-      open_time.strftime('%H:%M:%S')
-    end
+  property :open_time do
+    open_time&.strftime('%H:%M:%S')
   end
   property :open_day
-  property (:close_time) do
-  	if (close_time)
-      close_time.strftime('%H:%M:%S')
-    end
+  property :close_time do
+    close_time&.strftime('%H:%M:%S')
   end
   property :close_day
 end

--- a/db/migrate/20190331214423_add_time_columns_to_schedule_days.rb
+++ b/db/migrate/20190331214423_add_time_columns_to_schedule_days.rb
@@ -1,0 +1,8 @@
+class AddTimeColumnsToScheduleDays < ActiveRecord::Migration[5.0]
+  def change
+    add_column :schedule_days, :open_time, :time
+    add_column :schedule_days, :open_day, :string
+    add_column :schedule_days, :close_time, :time
+    add_column :schedule_days, :close_day, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190204014940) do
+ActiveRecord::Schema.define(version: 20190331214423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -265,6 +265,10 @@ ActiveRecord::Schema.define(version: 20190204014940) do
     t.integer  "opens_at"
     t.integer  "closes_at"
     t.integer  "schedule_id", null: false
+    t.time     "open_time"
+    t.string   "open_day"
+    t.time     "close_time"
+    t.string   "close_day"
     t.index ["schedule_id"], name: "index_schedule_days_on_schedule_id", using: :btree
   end
 

--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "6bc06566-eccc-4c85-af63-0b626bd223a3",
+		"_postman_id": "51a454ce-81c3-49cb-9467-96abbcd9e4c1",
 		"name": "AskDarcel API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1109,12 +1109,13 @@
 				{
 					"listen": "test",
 					"script": {
-						"type": "text/javascript",
+						"id": "a90c9522-8402-448b-bc6b-d2348fc3890b",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						]
+						],
+						"type": "text/javascript"
 					}
 				}
 			],
@@ -1132,7 +1133,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"services\": [\n    {\n      \"name\": \"Foo Service\",\n      \"long_description\": \"Bar description\",\n      \"eligibility\": \"foo\",\n      \"required_documents\": \"bar\",\n      \"fee\": \"foo\",\n      \"application_process\": \"bar\",\n      \"schedule\": {\n        \"schedule_days\": [\n          {\n            \"day\": \"Friday\",\n            \"opens_at\": 9,\n            \"closes_at\": 17\n          },\n          {\n            \"day\": \"Thursday\",\n            \"opens_at\": 9,\n            \"closes_at\": 17\n          },\n          {\n            \"day\": \"Wednesday\",\n            \"opens_at\": 9,\n            \"closes_at\": 17\n          },\n          {\n            \"day\": \"Tuesday\",\n            \"opens_at\": 11,\n            \"closes_at\": 19\n          },\n          {\n            \"day\": \"Monday\",\n            \"opens_at\": 11,\n            \"closes_at\": 19\n          }\n        ]\n      },\n      \"notes\": [\n        {\n          \"note\": \"foo\"\n        }\n      ],\n      \"categories\": [\n        {\n          \"id\": 3\n        }\n      ]\n    }\n  ]\n}"
+					"raw": "{\n  \"services\": [\n    {\n      \"name\": \"Foo Service\",\n      \"long_description\": \"Bar description\",\n      \"eligibility\": \"foo\",\n      \"required_documents\": \"bar\",\n      \"fee\": \"foo\",\n      \"application_process\": \"bar\",\n      \"schedule\": {\n        \"schedule_days\": [\n          {\n            \"day\": \"Friday\",\n            \"opens_at\": 9,\n            \"closes_at\": 17,\n            \"open_day\": \"Friday\",\n            \"open_time\": \"9:00:00\",\n            \"close_day\": \"Friday\",\n            \"close_time\": \"17:00:00\"\n          },\n          {\n            \"day\": \"Thursday\",\n            \"opens_at\": 9,\n            \"closes_at\": 17,\n            \"open_day\": \"Thursday\",\n            \"open_time\": \"9:00:00\",\n            \"close_day\": \"Thursday\",\n            \"close_time\": \"17:00:00\"\n          },\n          {\n            \"day\": \"Wednesday\",\n            \"opens_at\": 9,\n            \"closes_at\": 17,\n            \"open_day\": \"Wednesday\",\n            \"open_time\": \"9:00:00\",\n            \"close_day\": \"Wednesday\",\n            \"close_time\": \"17:00:00\"            \n          },\n          {\n            \"day\": \"Tuesday\",\n            \"opens_at\": 11,\n            \"closes_at\": 19,\n            \"open_day\": \"Tuesday\",\n            \"open_time\": \"9:00:00\",\n            \"close_day\": \"Tuesday\",\n            \"close_time\": \"17:00:00\"  \n          },\n          {\n            \"day\": \"Monday\",\n            \"opens_at\": 11,\n            \"closes_at\": 19,\n            \"open_day\": \"Monday\",\n            \"open_time\": \"9:00:00\",\n            \"close_day\": \"Monday\",\n            \"close_time\": \"17:00:00\"  \n          }\n        ]\n      },\n      \"notes\": [\n        {\n          \"note\": \"foo\"\n        }\n      ],\n      \"categories\": [\n        {\n          \"id\": 3\n        }\n      ]\n    }\n  ]\n}"
 				},
 				"url": {
 					"raw": "{{base_url}}/resources/1/services",
@@ -1154,12 +1155,13 @@
 				{
 					"listen": "test",
 					"script": {
-						"type": "text/javascript",
+						"id": "1ebb6056-c993-4807-a34d-fa47edd4fee3",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						]
+						],
+						"type": "text/javascript"
 					}
 				}
 			],
@@ -1177,7 +1179,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"resources\":[{\"name\":\"Test new\",\"address\":{\"address_1\":\"601 4th Street\",\"city\":\"San Francisco\",\"state_province\":\"CA\",\"country\":\"USA\",\"postal_code\":\"49032\"},\"long_description\":\"test\",\"email\":\"test@test.com\",\"website\":\"test.com\",\"notes\":[],\"schedule\":{\"schedule_days\":[{\"day\":\"Monday\",\"opens_at\":0,\"closes_at\":2359},{\"day\":\"Tuesday\",\"opens_at\":109,\"closes_at\":1753},{\"day\":\"Wednesday\",\"opens_at\":null,\"closes_at\":null},{\"day\":\"Thursday\",\"opens_at\":null,\"closes_at\":null},{\"day\":\"Friday\",\"opens_at\":null,\"closes_at\":null},{\"day\":\"Saturday\",\"opens_at\":null,\"closes_at\":null},{\"day\":\"Sunday\",\"opens_at\":null,\"closes_at\":null}]},\"phones\":[{\"number\":\"4155555555\",\"service_type\":\"English\"}]\n}]}"
+					"raw": "{\"resources\":[{\"name\":\"Test new\",\"address\":{\"address_1\":\"601 4th Street\",\"city\":\"San Francisco\",\"state_province\":\"CA\",\"country\":\"USA\",\"postal_code\":\"49032\"},\"long_description\":\"test\",\"email\":\"test@test.com\",\"website\":\"test.com\",\"notes\":[],\"schedule\":{\"schedule_days\":[{\"day\":\"Monday\",\"opens_at\":900,\"closes_at\":1000,\"open_time\":\"09:00:00\",\"open_day\":\"Monday\",\"close_time\":\"10:00:00\",\"close_day\":\"Monday\"},{\"day\":\"Tuesday\",\"opens_at\":100,\"closes_at\":1000,\"open_time\":\"09:00:00\",\"open_day\":\"Tuesday\",\"close_time\":\"10:00:00\",\"close_day\":\"Tuesday\"}]},\"phones\":[{\"number\":\"4155555555\",\"service_type\":\"English\"}]\n}]}"
 				},
 				"url": {
 					"raw": "{{base_url}}/resources",
@@ -1550,8 +1552,7 @@
 						"resources",
 						"count"
 					]
-				},
-				"description": null
+				}
 			},
 			"response": []
 		}


### PR DESCRIPTION
See #399 -- Added time fields for more intuitive storage of open and close times, and added open and close day fields to represent cases where open and close occur across days. Left old fields in for backwards compatibility; will remove when front end and external partners are using new fields.