### PR TITLE
Tweak Algolia reindex logging for GCP

### DIFF
--- a/lib/tasks/algolia.rake
+++ b/lib/tasks/algolia.rake
@@ -2,8 +2,8 @@
 
 namespace :algolia do
   task reindex: :environment do
-    print "Reindexing resource/service index... "
+    puts '[algolia:reindex] Reindexing resource/service index...'
     AlgoliaReindexJob.new.perform
-    puts "success."
+    puts '[algolia:reindex] Success.'
   end
 end


### PR DESCRIPTION
Since a log entry will not appear in GCP logs until a newline is
written, eagerly write a log entry with a newline before starting the
Algolia reindex job. Helps us distinguish between job start and job
finish.