### PR TITLE
[673] Added onetime rake task to fix service schedule inheritance

### DIFF
--- a/lib/tasks/onetime.rake
+++ b/lib/tasks/onetime.rake
@@ -51,11 +51,15 @@ namespace :onetime do
           'ON resources.id = services.resource_id ' \
           'AND resources.id = schedules.resource_id')
       schedules.each do |s|
-        puts 'Service id %i shares schedule %i with Resource id %i' % [s.service_id, s.id, s.resource_id]
-        Schedule.update(s.id, :service_id => nil)
+        puts format(
+          'Service id %<service_id>i shares schedule %<schedule_id>i with Resource id %<resource_id>i',
+          service_id: s.service_id,
+          schedule_id: s.id,
+          resource_id: s.resource_id
+        )
+        Schedule.update(s.id, service_id: nil)
       end
-      puts 'Updated %i schedule records with nil service_id' % [schedules.length]
+      puts format('Updated %<num>i schedule records with nil service_id', num: schedules.length)
     end
   end
-
 end

--- a/lib/tasks/onetime.rake
+++ b/lib/tasks/onetime.rake
@@ -57,6 +57,7 @@ namespace :onetime do
           schedule_id: s.id,
           resource_id: s.resource_id
         )
+        Schedule.create(resource_id: nil, service_id: s.service_id)
         Schedule.update(s.id, service_id: nil)
       end
       puts format('Updated %<num>i schedule records with nil service_id', num: schedules.length)


### PR DESCRIPTION
Running this rake task on a copy of the staging db produces the following log (modifying 216 records):

[fix_service_schedule_inheritance_output.txt](https://github.com/ShelterTechSF/askdarcel-api/files/3077561/fix_service_schedule_inheritance_output.txt)

As expected, the schedules that have both service_id and resource_id fields populated are (presumably) legacy data where the referenced services belong to the referenced resources.
Running a query for schedules with non-nil service_id and non-nil resource_id on the staging data produces the following:
```
irb(main):004:0> s = Schedule.where.not(service_id: nil).where.not(resource_id: nil)
  Schedule Load (1.3ms)  SELECT "schedules".* FROM "schedules" WHERE ("schedules"."service_id" IS NOT NULL) AND ("schedules"."resource_id" IS NOT NULL)
=> #<ActiveRecord::Relation [#<Schedule id: 1, created_at: "2017-03-03 00:58:29", updated_at: "2017-03-03 00:58:29", resource_id: 1, service_id: 1>, #<Schedule id: 2, created_at: "2017-03-03 00:58:30", updated_at: "2017-03-03 00:58:30", resource_id: 2, service_id: 2>, #<Schedule id: 3, created_at: "2017-03-03 00:58:31", updated_at: "2017-03-03 00:58:31", resource_id: 3, service_id: 3>, #<Schedule id: 4, created_at: "2017-03-03 00:58:32", updated_at: "2017-03-03 00:58:32", resource_id: 4, service_id: 4>, #<Schedule id: 5, created_at: "2017-03-03 00:58:33", updated_at: "2017-03-03 00:58:33", resource_id: 5, service_id: 5>, #<Schedule id: 6, created_at: "2017-03-03 00:58:34", updated_at: "2017-03-03 00:58:34", resource_id: 6, service_id: 6>, #<Schedule id: 7, created_at: "2017-03-03 00:58:35", updated_at: "2017-03-03 00:58:35", resource_id: 7, service_id: 7>, #<Schedule id: 8, created_at: "2017-03-03 00:58:36", updated_at: "2017-03-03 00:58:36", resource_id: 8, service_id: 8>, #<Schedule id: 9, created_at: "2017-03-03 00:58:37", updated_at: "2017-03-03 00:58:37", resource_id: 9, service_id: 9>, #<Schedule id: 11, created_at: "2017-03-03 00:58:38", updated_at: "2017-03-03 00:58:38", resource_id: 10, service_id: 11>, ...]>
irb(main):005:0> s.count
   (0.8ms)  SELECT COUNT(*) FROM "schedules" WHERE ("schedules"."service_id" IS NOT NULL) AND ("schedules"."resource_id" IS NOT NULL)
=> 216
```

After the rake task:
```
irb(main):003:0> Schedule.where.not(service_id: nil).where.not(resource_id: nil)
  Schedule Load (1.2ms)  SELECT "schedules".* FROM "schedules" WHERE ("schedules"."service_id" IS NOT NULL) AND ("schedules"."resource_id" IS NOT NULL)
=> #<ActiveRecord::Relation []>
```

I welcome any suggestions on incorporating that data verification query into a test (postman doesn't feel like an appropriate place for that?) or any other preventative measures for the future.