### PR TITLE
Enable eager loading of code in order to avoid deadlocking issue.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,8 +8,15 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
+  ## COMMENTED OUT
   # Do not eager load code on boot.
-  config.eager_load = false
+  # config.eager_load = false
+  ## COMMENTED OUT
+
+  # Actually do eager load code on boot to workaround a concurrency/deadlocking
+  # issue in Puma.
+  # https://github.com/puma/puma/issues/1184
+  config.eager_load = true
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,10 +9,17 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  ## COMMENTED OUT
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # config.eager_load = false
+  ## COMMENTED OUT
+
+  # Actually do eager load code on boot to workaround a concurrency/deadlocking
+  # issue in Puma.
+  # https://github.com/puma/puma/issues/1184
+  config.eager_load = true
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
I found a GitHub ticket on the Puma project that described a problem similar to what we were seeing, and there's a workaround that they suggested that seemed to work for me: https://github.com/puma/puma/issues/1184

This PR turns on `eager_load` in both development and testing environments, which apparently works around the deadlocking issue that can cause the API server to hang.