### PR TITLE
Introduce Algolia incremental index job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,11 +30,6 @@ gem 'lograge'
 
 gem 'prometheus-client'
 
-# Background Job Processing
-gem 'daemons'
-gem 'delayed_job_active_record'
-gem 'whenever', require: false
-
 gem 'rspec-rails'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,15 +57,8 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.0.1)
-    chronic (0.10.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
-    daemons (1.3.1)
-    delayed_job (4.1.7)
-      activesupport (>= 3.0, < 5.3)
-    delayed_job_active_record (4.1.3)
-      activerecord (>= 3.0, < 5.3)
-      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     dotenv (2.7.4)
     dotenv-rails (2.7.4)
@@ -245,8 +238,6 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
@@ -255,8 +246,6 @@ DEPENDENCIES
   algoliasearch-rails
   bullet
   byebug
-  daemons
-  delayed_job_active_record
   dotenv-rails
   factory_bot_rails
   faker
@@ -276,7 +265,6 @@ DEPENDENCIES
   rubocop
   sentry-raven
   spring
-  whenever
 
 BUNDLED WITH
    1.17.1

--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ $ docker-compose build
 # Start the database container (in the background with -d)
 $ docker-compose up -d db
 
-# (Optional) start the background worker container (in the background with -d)
-$ docker-compose up -d worker
-
 # Generate random database fixtures
 $ docker-compose run --rm api rake db:setup db:populate
 

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -180,10 +180,17 @@ class ChangeRequestsController < ApplicationController
       puts 'invalid request'
     end
 
+    resource = change_request.resource
+    return unless resource.present?
+
+    # Touch 'updated_at' for resource. Signals to other systems that this
+    # resource and/or its services have been modified.
+    resource.touch
+
     if Rails.configuration.x.algolia.enabled
       # Update Algolia index for both the resource and all its services
-      change_request.resource&.index!
-      change_request.resource&.services.each &:index!
+      resource.index!
+      resource.services.to_a.each &:index!
     end
   end
 

--- a/app/jobs/algolia_incremental_index_job.rb
+++ b/app/jobs/algolia_incremental_index_job.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Visits all Resources that have been updated since the last time this job ran.
+# Syncs these resources and all of their services to Algolia.
+#
+# Stores a bookmark, allowing it to pick up where it left off last time and
+# query for recently updated Resources.
+#
+# Saves approved Resources and Services to Algolia, removes all others from
+# Algolia.
+#
+# Usage:
+#
+#   > AlgoliaIncrementalIndexJob.new.perform
+#
+class AlgoliaIncrementalIndexJob
+  BATCH_SIZE = 50
+  BOOKMARK_IDENTIFIER = 'algolia-incremental-index-resources-bookmark'
+
+  def perform
+    Rails.logger.info('Beginning incremental index of updated resources and their services...')
+    bookmark = find_or_create_bookmark
+    resource_counts = { updated: 0, removed: 0 }
+    service_counts = { updated: 0, removed: 0 }
+    scan_through_recently_updated_resources(bookmark) do |resource|
+      process_resource(resource, resource_counts, service_counts)
+    end
+    Rails.logger.info("Done. resource counts: #{resource_counts}, service counts: #{service_counts}")
+  end
+
+  private
+
+  def process_resource(resource, resource_counts, service_counts)
+    process_record(resource, resource_counts)
+    resource.services.each do |service|
+      process_record(service, service_counts)
+    end
+  end
+
+  def process_record(record, counts)
+    if record.approved?
+      update_in_algolia!(record)
+      counts[:updated] += 1
+    else
+      remove_from_algolia!(record)
+      counts[:removed] += 1
+    end
+  end
+
+  def find_or_create_bookmark
+    Bookmark.create_with(date_value: 20.years.ago, id_value: 0)
+            .find_or_create_by(identifier: BOOKMARK_IDENTIFIER)
+  end
+
+  def scan_through_recently_updated_resources(bookmark)
+    loop do
+      batch = query_next_batch(bookmark)
+      break if batch.empty?
+
+      batch.each { |resource| yield resource }
+      last = batch.last
+      bookmark.update(date_value: last.updated_at, id_value: last.id)
+      Rails.logger.info("Bookmark updated. #{bookmark.identifier} - "\
+                        "date_value: #{bookmark.date_value}, "\
+                        "id_value: #{bookmark.id_value}")
+    end
+  end
+
+  def query_next_batch(bookmark)
+    uat = bookmark.date_value
+    id = bookmark.id_value
+    Resource.where('(updated_at, id) > (:updated_at, :id)', updated_at: uat, id: id)
+            .order(Arel.sql('(updated_at, id) ASC'))
+            .limit(BATCH_SIZE)
+            .to_a
+  end
+
+  def update_in_algolia!(record)
+    return unless Rails.configuration.x.algolia.enabled
+
+    record.index!
+  end
+
+  def remove_from_algolia!(record)
+    return unless Rails.configuration.x.algolia.enabled
+
+    record.remove_from_index!
+  end
+end

--- a/app/jobs/algolia_reindex_job.rb
+++ b/app/jobs/algolia_reindex_job.rb
@@ -13,10 +13,6 @@
 # > AlgoliaReindexJob.new.perform
 #
 class AlgoliaReindexJob
-  def self.perform_async
-    Delayed::Job.enqueue(AlgoliaReindexJob.new)
-  end
-
   def perform
     Resource.where(status: :approved).reindex
     # Since Service and Resource share an algolia index, we use `reindex!` so

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Represents the `bookmarks` table. If a cronjob or some other system is
+# scanning through a database table and needs to save its current place, it can
+# save a bookmark to allow it to pick up again where it left off.
+#
+# For example, the Algolia incremental indexing cronjob might run periodically
+# to index all Resources that have been updated since the last time it ran. The
+# cronjob can simply do something like this:
+#
+#   bookmark = Bookmark.where(identifier: 'algolia-index-resources').take
+#   prev_updated_at = bookmark.date_value
+#   resources_to_index = Resource.where('updated_at > ?', prev_updated_at)
+#   ...
+#   bookmark.update(date_value: new_updated_at)
+#
+# Bookmarks have a date_value column and an id_value column which can be used
+# to store data needed to keep your place in a scan.
+class Bookmark < ActiveRecord::Base
+end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
-require 'delayed/command'
-Delayed::Command.new(ARGV).daemonize

--- a/bin/worker_restart.sh
+++ b/bin/worker_restart.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Use whenever gem to update crontab from config/schedule.rb
-whenever --update-crontab
-
-# Restart delayed_job worker process
-./bin/delayed_job restart

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,5 @@ module AskdarcelApi
         ActiveRecord::Migrator.migrate ::Rails.root.to_s + "/db/migrate"
       end
     end
-
-    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/db/migrate/20190613040858_add_updated_at_index_to_resources.rb
+++ b/db/migrate/20190613040858_add_updated_at_index_to_resources.rb
@@ -1,0 +1,11 @@
+# Add index on updated_at datetime to resources. This allows us to walk through
+# recent updates efficiently, which is particularly useful for performing
+# incremental Algolia indexing.
+#
+# We index on both `updated_at` and `id` to make efficient pagination possible
+# even if a large number of records have exactly the same `updated_at` value.
+class AddUpdatedAtIndexToResources < ActiveRecord::Migration[5.0]
+  def change
+    add_index :resources, %i[updated_at id]
+  end
+end

--- a/db/migrate/20190613041725_create_bookmarks.rb
+++ b/db/migrate/20190613041725_create_bookmarks.rb
@@ -1,0 +1,14 @@
+# Create the `bookmarks` table. If a cronjob or some other system is scanning
+# through a database table and needs to save its current place, it can save a
+# bookmark.
+class CreateBookmarks < ActiveRecord::Migration[5.0]
+  def change
+    create_table :bookmarks do |t|
+      t.string 'identifier'
+      t.datetime 'date_value'
+      t.integer 'id_value'
+      t.timestamps
+      t.index ['identifier'], unique: true
+    end
+  end
+end

--- a/db/migrate/20190613054936_drop_delayed_jobs.rb
+++ b/db/migrate/20190613054936_drop_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class DropDelayedJobs < ActiveRecord::Migration[5.0]
+  def up
+    drop_table :delayed_jobs
+  end
+
+  def down
+    create_table "delayed_jobs" do |t|
+      t.integer  "priority",   default: 0, null: false
+      t.integer  "attempts",   default: 0, null: false
+      t.text     "handler",                null: false
+      t.text     "last_error"
+      t.datetime "run_at"
+      t.datetime "locked_at"
+      t.datetime "failed_at"
+      t.string   "locked_by"
+      t.string   "queue"
+      t.datetime "created_at"
+      t.datetime "updated_at"
+      t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190602224219) do
+ActiveRecord::Schema.define(version: 20190613054936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,15 @@ ActiveRecord::Schema.define(version: 20190602224219) do
     t.index ["uid", "provider"], name: "index_admins_on_uid_and_provider", unique: true, using: :btree
   end
 
+  create_table "bookmarks", force: :cascade do |t|
+    t.string   "identifier"
+    t.datetime "date_value"
+    t.integer  "id_value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["identifier"], name: "index_bookmarks_on_identifier", unique: true, using: :btree
+  end
+
   create_table "categories", force: :cascade do |t|
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
@@ -118,21 +127,6 @@ ActiveRecord::Schema.define(version: 20190602224219) do
     t.integer  "service_id"
     t.index ["resource_id"], name: "index_contacts_on_resource_id", using: :btree
     t.index ["service_id"], name: "index_contacts_on_service_id", using: :btree
-  end
-
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
-    t.text     "last_error"
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 
   create_table "eligibilities", force: :cascade do |t|
@@ -252,6 +246,7 @@ ActiveRecord::Schema.define(version: 20190602224219) do
     t.integer  "source_attribution", default: 0
     t.index ["contact_id"], name: "index_resources_on_contact_id", using: :btree
     t.index ["funding_id"], name: "index_resources_on_funding_id", using: :btree
+    t.index ["updated_at", "id"], name: "index_resources_on_updated_at_and_id", using: :btree
   end
 
   create_table "reviews", force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,5 @@
 version: "3.5"
 
-# Common configuration for Rails processes.
-x-rails-common:
-  &rails-common
-  build:
-    context: .
-    dockerfile: Dockerfile.dev
-  depends_on:
-    - db
-  environment:
-    DATABASE_URL: postgres://postgres@db/askdarcel_development
-    TEST_DATABASE_URL: postgres://postgres@db/askdarcel_test
-    ALGOLIA_APPLICATION_ID:
-    ALGOLIA_API_KEY:
-    ALGOLIA_INDEX_PREFIX:
-  networks:
-    - askdarcel
-  volumes:
-    - .:/usr/src/app
-    # Avoid leftover server.pid files when container exits.
-    # https://auth0.com/blog/ruby-on-rails-killer-workflow-with-docker-part-1/
-    - type: tmpfs
-      target: /usr/src/app/tmp/pids
-
 services:
   db:
     image: "postgres:9.5"
@@ -30,14 +7,28 @@ services:
       - askdarcel
 
   api:
-    << : *rails-common
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgres://postgres@db/askdarcel_development
+      TEST_DATABASE_URL: postgres://postgres@db/askdarcel_test
+      ALGOLIA_APPLICATION_ID:
+      ALGOLIA_API_KEY:
+      ALGOLIA_INDEX_PREFIX:
+    networks:
+      - askdarcel
+    volumes:
+      - .:/usr/src/app
+      # Avoid leftover server.pid files when container exits.
+      # https://auth0.com/blog/ruby-on-rails-killer-workflow-with-docker-part-1/
+      - type: tmpfs
+        target: /usr/src/app/tmp/pids
     command: rails server --port=3000 --binding=0.0.0.0
     ports:
       - "3000:3000"
-
-  worker:
-    << : *rails-common
-    command: rake jobs:work
 
   postman:
     build:

--- a/lib/sheltertech/db/staging_importer.rb
+++ b/lib/sheltertech/db/staging_importer.rb
@@ -121,8 +121,6 @@ module ShelterTech
           # Leave out built-in tables, like schema migrations
           next if model_name == 'ApplicationRecord'
           next if model_name.starts_with? 'ActiveRecord::'
-          # Leave out `DelayedJob` table
-          next if model_name.starts_with? 'Delayed::'
 
           ret << model.table_name
         end

--- a/lib/tasks/algolia.rake
+++ b/lib/tasks/algolia.rake
@@ -6,4 +6,10 @@ namespace :algolia do
     AlgoliaReindexJob.new.perform
     puts '[algolia:reindex] Success.'
   end
+
+  task incremental_index: :enviroment do
+    puts '[algolia:incremental_index] Indexing recent updates to resources/services...'
+    AlgoliaIncrementalIndexJob.new.perform
+    puts '[algolia:incremental_index] Success.'
+  end
 end

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bookmark do
+    identifier { Faker::Lorem.name }
+    date_value { 20.years.ago }
+    id_value { 0 }
+  end
+end

--- a/spec/jobs/algolia_incremental_index_job_spec.rb
+++ b/spec/jobs/algolia_incremental_index_job_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Algolia Incremental Index Job' do
+  let!(:resources) { create_list(:resource, 3, status: :approved) }
+  let!(:services) { create_list(:service, 3, status: :approved, resource: resources.last) }
+  let(:bookmark_identifier) { 'algolia-incremental-index-resources-bookmark' }
+
+  context 'when this is the first time the job has run' do
+    it 'creates bookmark for resources' do
+      expect(Bookmark.count).to eq(0)
+
+      AlgoliaIncrementalIndexJob.new.perform
+
+      expect(Bookmark.count).to eq(1)
+      bm = Bookmark.where(identifier: bookmark_identifier).take
+      expect(bm.date_value).to eq(Resource.maximum(:updated_at))
+    end
+  end
+
+  context 'when this job has run before and has prior bookmark' do
+    let(:already_processed_resource) { Resource.order('(updated_at, id) ASC').take }
+    let(:already_processed_services) do
+      create_list(:service, 2, resource: already_processed_resource)
+    end
+
+    before(:each) do
+      create(:bookmark, identifier: bookmark_identifier,
+                        date_value: already_processed_resource.updated_at,
+                        id_value: already_processed_resource.id)
+    end
+
+    it 'updates the bookmarks' do
+      job = AlgoliaIncrementalIndexJob.new
+
+      updated = []
+      allow(job).to receive(:update_in_algolia!) do |record|
+        updated << record
+      end
+
+      removed = []
+      allow(job).to receive(:remove_from_algolia!) do |record|
+        removed << record
+      end
+
+      job.perform
+
+      expect(Bookmark.count).to eq(1)
+      bm = Bookmark.where(identifier: bookmark_identifier).take
+      expect(bm.date_value).to eq(Resource.maximum(:updated_at))
+
+      expect(removed).to be_empty
+
+      expect(updated.size).to eq(5)
+      updated_resources = updated.select { |u| u.is_a?(Resource) }
+      updated_services = updated.select { |u| u.is_a?(Service) }
+      expect(updated_resources.size).to eq(2)
+      expect(updated_services.size).to eq(3)
+      expect(updated_resources.map(&:id)).not_to include(already_processed_resource.id)
+      intersection = updated_services.map(&:id) & already_processed_services.map(&:id)
+      expect(intersection).to be_empty
+    end
+  end
+
+  context 'when some resources are not approved' do
+    let!(:inactive_resource) do
+      resource = Resource.order(id: :desc).take
+      resource.update(status: :inactive)
+      resource
+    end
+
+    it 'syncs approved resources to algolia but deletes all others' do
+      job = AlgoliaIncrementalIndexJob.new
+
+      updated = []
+      allow(job).to receive(:update_in_algolia!) do |record|
+        updated << record
+      end
+
+      removed = []
+      allow(job).to receive(:remove_from_algolia!) do |record|
+        removed << record
+      end
+
+      job.perform
+
+      expect(updated.size).to eq(5)
+      expect(updated.map(&:approved?).uniq).to eq([true])
+      expect(removed.size).to eq(1)
+      expect(removed.first.id).to eq(inactive_resource.id)
+
+      expect(Bookmark.count).to eq(1)
+      bm = Bookmark.where(identifier: bookmark_identifier).take
+      expect(bm.date_value).to eq(Resource.maximum(:updated_at))
+    end
+  end
+end

--- a/spec/jobs/algolia_reindex_job_spec.rb
+++ b/spec/jobs/algolia_reindex_job_spec.rb
@@ -3,29 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe 'Algolia Reindex Job' do
-  context 'when scheduling a reindex job' do
-    it 'enqueues a new background job properly' do
-      expect(Delayed::Job.all).to be_empty
+  it 'runs Algolia reindex operation on the expected models' do
+    resource_query = double
+    expect(Resource).to receive(:where).with(status: :approved).and_return(resource_query)
+    expect(resource_query).to receive(:reindex)
 
-      AlgoliaReindexJob.perform_async
+    service_query = double
+    expect(Service).to receive(:where).with(status: :approved).and_return(service_query)
+    expect(service_query).to receive(:reindex!)
 
-      expect(Delayed::Job.count).to eq(1)
-      delayed_job = Delayed::Job.first
-      expect(delayed_job.handler).to include('AlgoliaReindexJob')
-    end
-  end
-
-  context 'when executing a reindex job' do
-    it 'runs Algolia reindex operation on the expected models' do
-      resource_query = double
-      expect(Resource).to receive(:where).with(status: :approved).and_return(resource_query)
-      expect(resource_query).to receive(:reindex)
-
-      service_query = double
-      expect(Service).to receive(:where).with(status: :approved).and_return(service_query)
-      expect(service_query).to receive(:reindex!)
-
-      AlgoliaReindexJob.new.perform
-    end
+    AlgoliaReindexJob.new.perform
   end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -3,5 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe Service, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'after each update, touches the updated_at time of the associated resource' do
+    # In other words, confirm that relationship between service and resource
+    # has `touch: true` set. Thus, whenever a service is changed, the
+    # `updated_at` of its associated resource will be touched, i.e. set to the
+    # present.
+    resource = create(:resource)
+    service = create(:service, resource: resource)
+    Resource.where(id: resource.id).update_all(updated_at: 1.hour.ago)
+    expect(resource.reload.updated_at.to_i).to be_within(2).of(1.hour.ago.to_i)
+
+    service.update(name: 'My Service Name')
+
+    expect(resource.reload.updated_at.to_i).to be_within(2).of(Time.now.to_i)
+  end
 end

--- a/spec/requests/resources/change_requests/create_spec.rb
+++ b/spec/requests/resources/change_requests/create_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Resource Change Requests' do
-  let(:resource) { create :resource }
+  let!(:resource) { create :resource }
   let(:params) do
     {
       name: 'New Name',
@@ -12,6 +12,8 @@ RSpec.describe 'Resource Change Requests' do
   end
 
   it 'creates a change request and associated field changes' do
+    resource.update(updated_at: 1.hour.ago)
+
     post "/resources/#{resource.id}/change_requests", params: { change_request: params }
 
     expect(resource.reload.name).to eq(params[:name])
@@ -29,6 +31,9 @@ RSpec.describe 'Resource Change Requests' do
       params[:name]
     ]
     expect(field_changes.map(&:field_value)).to eq(expected_field_values)
+
+    # Verify that `updated_at` field have been set to the present.
+    expect(resource.reload.updated_at.to_i).to be_within(5).of(Time.now.to_i)
 
     expect(response_json).to match(
       'resource_change_request' => {


### PR DESCRIPTION
This job scans through all of the resources that have been updated since
the last time it ran. Approved resources and their approved services are
updated in Algolia, and all others are removed from Algolia.

We introduce a new table named `bookmarks` that allows the job to pick
up again from where it left off the last time it ran.

Updated ChangeRequestsController to make it so the `updated_at` time of
the associated Resource is touched whenever a ChangeRequest is applied.
Allows the Algolia incremental index job to detect updates.

Remove the deprecated `Delayed::Job` system. It has been replaced for a
while now by the k8s CronJob setup.
