### PR TITLE
402: Sending environment in config to Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,7 +4,8 @@ Raven.configure do |config|
   SENTRY_PUBLIC_KEY = 'd35c8b2336084e67b08f7c4b5eeb54b9'
   SENTRY_PROJECT_ID = '1291517'
   config.dsn = "https://#{SENTRY_PUBLIC_KEY}@sentry.io/#{SENTRY_PROJECT_ID}"
-
+  # Send the environment to Sentry (development/testing/production)
+  config.environments = [Rails.env]
   # Filter out sensitive parameters such as passwords
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end


### PR DESCRIPTION
Giving ability to filter error reports on Sentry by sending environment
information during initialization
https://docs.sentry.io/enriching-error-data/environments/?platform=javascript

Issue: https://github.com/ShelterTechSF/askdarcel-api/issues/402
Branch: 402-sentry-env-split