### PR TITLE
Allow access to rails tools from terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ $ docker-compose run --rm api rake db:create db:schema:load linksf:import
 $ docker-compose run -e STAGING_DB_PASSWORD=<...> --rm api rake db:setup db:import_staging
 ```
 
+### Running tools from the terminal
+Due to the DB and API being contained inside Docker containers, running ruby/rails specific tools without having to ssh into the containers involves specific steps
+#### Running the rails console from the terminal
+```sh
+# Start both the DB and API
+$ cd PATH/TO/askdarcel-api
+$ docker-compose run --rm api rails console
+```
+
+#### Running byebug from the terminal
+```sh
+# Start both the DB and API
+$ docker attach $(docker ps -aqf "name=askdarcel-api_api")
+```
 
 ## macOS-based Development Environment Not Using Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,10 @@ services:
     command: rails server --port=3000 --binding=0.0.0.0
     ports:
       - "3000:3000"
+    # Creates a psuedoterminal that connects a user's "terminal" with the stdin and stdout stream
+    tty: true
+    # Opens the docker container to input from the terminal
+    stdin_open: true
 
   postman:
     build:


### PR DESCRIPTION
- previously, one had to ssh into the docker container to
  track byebug or run the rails console
- create a psudoterminal to the api docker container and
  allow input for it
- update readme to explain how to run the rails console and
  byebug
- https://stackoverflow.com/questions/31669226/rails-byebug-did-not-stop-application/32690885#32690885
- https://medium.com/@ddomachine/docker-and-ruby-on-rails-448ab8255f97