### PR TITLE
Check for nil or empty addresses in Algolia index.

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -39,7 +39,11 @@ class Resource < ActiveRecord::Base
       attributesForFaceting %i[categories open_times]
       # Define attributes used to build an Algolia record
       add_attribute :_geoloc do
-        { lat: addresses[0].latitude.to_f, lng: addresses[0].longitude.to_f }
+        if addresses.blank?
+          nil
+        else
+          { lat: addresses[0].latitude.to_f, lng: addresses[0].longitude.to_f }
+        end
       end
 
       add_attribute :status


### PR DESCRIPTION
Should fix the issue we're seeing in staging with reindexing.

I haven't tested it, since I don't have an easy way to reproduce the error in staging, but I double checked that `.blank?` in Rails means either `.nil?` or `.empty?`, so it should account for a null value or an empty array.