### PR TITLE
Set Environment Variable POSTGRES_HOST_AUTH_METHOD to trust

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.5"
 
 services:
   db:
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
     image: "postgres:9.5"
     networks:
       - askdarcel


### PR DESCRIPTION
For docker-compose.yml, postgres requires a password to be
set for docker to work. This change sets postgres to not
require a password.