### PR TITLE
Only push Docker image on non-PR builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,11 @@ script:
   - ./travis/postman.sh
 
 after_success:
-  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - export TAG=`if [[ -n "$TRAVIS_TAG" ]]; then echo "$TRAVIS_TAG"; else if [ "$SANITIZED_BRANCH" == "master" ]; then echo "latest"; fi; fi`
-  - docker build -f Dockerfile -t $REPO:$TAG .
-  - docker push $REPO
+  - docker build -f Dockerfile -t "$REPO:$TAG" .
+  - |
+    set -euo pipefail
+    if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+      docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+      docker push "$REPO"
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ after_success:
   - export TAG=`if [[ -n "$TRAVIS_TAG" ]]; then echo "$TRAVIS_TAG"; else if [ "$SANITIZED_BRANCH" == "master" ]; then echo "latest"; fi; fi`
   - docker build -f Dockerfile -t "$REPO:$TAG" .
   - |
-    set -euo pipefail
+    set -eo pipefail
     if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
       docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
       docker push "$REPO"


### PR DESCRIPTION
This is not only unnecessary to do on PR builds, but it also prevents builds on PRs coming from forks of the repository from succeeding, since the Docker Hub API keys are not available on forks.

This should fix the issue in https://github.com/ShelterTechSF/askdarcel-api/pull/500#issuecomment-590192394.

I am submitting this from a personal fork of askdarcel-api to test if that this does in fact work.