### PR TITLE
Add Phone numbers to Algolia index.

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -102,6 +102,12 @@ class Resource < ActiveRecord::Base
           { name: s.name }
         end
       end
+
+      add_attribute :phones do
+        phones.map do |p|
+          { number: p.number, service_type: p.service_type }
+        end
+      end
     end
     # rubocop:enable Metrics/BlockLength
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -124,6 +124,20 @@ class Service < ActiveRecord::Base
         eligibilities.map(&:name)
       end
 
+      add_attribute :phones do
+        # Currently there's no relationship between Services -> Phones, only
+        # Resources <-> Phones. Even though the DB schema currently has a
+        # foreign key between Phone and Service, the has_many association hasn't
+        # been declared, and we don't have a user-facing edit page which exposes
+        # this anyway, so we'd have to re-vet the data to fill in this
+        # information anyway.
+        #
+        # Therefore, this just grabs the resource's phone numbers.
+        resource.phones.map do |p|
+          { number: p.number, service_type: p.service_type }
+        end
+      end
+
       # add_attribute :keywords do
       #   keywords.map(&:name)
       # end


### PR DESCRIPTION
For the new service discovery search page, we need the phone number to be returned as part of the Algolia search, which means that Algolia needs to actually index the phone numbers.

This was straightforward for Resources, but for Services, despite the fact that we have a foreign key between Phone and Service, we don't declare the `has_many` or `belongs_to` ActiveRecord associations in the models, and we don't ever even expose this in the Edit page's UI, so in practice, none of our data in our production DB actually has the Phone -> Service relationship set.

For now, I just have the Service look at the Resource's Phones when creating the data in Algolia index.

I tested this locally and confirmed that I'm now seeing phone number info in the Algolia index.