### PR TITLE
Add eligibilities as an Algolia facet.

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -37,7 +37,7 @@ class Resource < ActiveRecord::Base
     # rubocop:disable Metrics/BlockLength
     algoliasearch index_name: "#{Rails.configuration.x.algolia.index_prefix}_services_search", id: :algolia_id do
       # specify the list of attributes available for faceting
-      attributesForFaceting %i[categories open_times]
+      attributesForFaceting %i[categories open_times eligibilities]
       # Define attributes used to build an Algolia record
       add_attribute :_geoloc do
         if addresses.blank?


### PR DESCRIPTION
I was seeing some weird behavior locally where my app suddenly stopped showing any of the eligibility options as a valid way of filtering in Algolia.

The equivalent line in service.rb already lists `eligibilities` as a facetable attribute. My hypothesis is that the weird thing we're doing by combining Resource and Service into a single Algolia index is confusing Algolia whenever we set index-level properties, such as the attributesForFaceting, and there might be a race condition depending on which one runs last.