### PR TITLE
Update Algolia re-index to use Resource Address if Service Address do…

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -40,7 +40,7 @@ class Service < ActiveRecord::Base
             { lat: a.latitude.to_f, lng: a.longitude.to_f } \
               if a.latitude.present? && a.longitude.present?
           end
-        elsif !addresses.blank? && resource.addresses[0].latitude.present? && resource.addresses[0].longitude.present?
+        elsif !resource.addresses.blank? && resource.addresses[0].latitude.present? && resource.addresses[0].longitude.present?
           { lat: resource.addresses[0].latitude.to_f, lng: resource.addresses[0].longitude.to_f }
         end
       end


### PR DESCRIPTION
The problem here was that some services were not updating the "_geoloc" field in Algolia index.

This section of code that is meant to check for a Resource Address was never passing, this should be the proper check.

Verified in dev that Algolia reindex went from not populating _geoloc to populating it as expected.