### PR TITLE
1709 one time rake associate sf families resources and services

### DIFF
--- a/lib/tasks/sffamilies.rake
+++ b/lib/tasks/sffamilies.rake
@@ -11,17 +11,13 @@ namespace :sffamilies do
       # Find services that have the 'sffamilies' category name tag
       services = Service.joins(:categories).where(categories: { name: 'sffamilies' })
       services.each do |service|
+
         puts("Service id : #{service.id}, Service name: #{service.name}" \
         "from Resource id #{service.resource_id} has sffamilies category tag")
 
-        # Sites are not associated with Services currently
-        # service.sites.each do |service_site|
-        #   puts "#{service_site.id}"
-        # end
-
         # If the parent resource of the sffamilies service is not
         # connected to the site, append the site to it's list
-        resource = Resource.find_by(id: service.id)
+        resource = Resource.find_by(id: service.id)        
         unless resource.sites.include?(sffamilies)
           puts "Adding site association"
           new_sites = resource.sites.append(sffamilies)

--- a/lib/tasks/sffamilies.rake
+++ b/lib/tasks/sffamilies.rake
@@ -11,13 +11,12 @@ namespace :sffamilies do
       # Find services that have the 'sffamilies' category name tag
       services = Service.joins(:categories).where(categories: { name: 'sffamilies' })
       services.each do |service|
-
         puts("Service id : #{service.id}, Service name: #{service.name}" \
         "from Resource id #{service.resource_id} has sffamilies category tag")
 
         # If the parent resource of the sffamilies service is not
         # connected to the site, append the site to it's list
-        resource = Resource.find_by(id: service.id)        
+        resource = Resource.find_by(id: service.id)
         unless resource.sites.include?(sffamilies)
           puts "Adding site association"
           new_sites = resource.sites.append(sffamilies)

--- a/lib/tasks/sffamilies.rake
+++ b/lib/tasks/sffamilies.rake
@@ -1,41 +1,38 @@
 # frozen_string_literal: true
 
 namespace :sffamilies do
-  desc('Associate resources to the sffamilies site 
-    if a service from the resource has an sffamilies category tag')
+  desc('Associate resources to the sffamilies site based on service(s) with sffamilies category tag')
   task associate_resources: :environment do
     # Identify the sffamilites site
     sffamilies = Site.find_by(site_code: 'sffamilies')
     puts "Site Id: #{sffamilies.id}, Site Code: #{sffamilies.site_code}"
-    
+
     Resource.transaction do
       # Find services that have the 'sffamilies' category name tag
-      services = Service.joins(:categories).where(categories: {name: 'sffamilies'})
+      services = Service.joins(:categories).where(categories: { name: 'sffamilies' })
       services.each do |service|
-        
-        puts "Service id : #{service.id} / Service name #{service.name} from Resource id #{service.resource_id} has sffamilies category tag"
-        
+        puts("Service id : #{service.id}, Service name: #{service.name}" \
+        "from Resource id #{service.resource_id} has sffamilies category tag")
+
         # Sites are not associated with Services currently
         # service.sites.each do |service_site|
         #   puts "#{service_site.id}"
         # end
-        
+
         # If the parent resource of the sffamilies service is not
         # connected to the site, append the site to it's list
-        resource = Resource.find_by(id: service.id)        
+        resource = Resource.find_by(id: service.id)
         unless resource.sites.include?(sffamilies)
           puts "Adding site association"
           new_sites = resource.sites.append(sffamilies)
           Resource.update(resource.id, sites: new_sites)
-        else
-          puts "Site is already associated"
         end
 
         # Provide an updated list of the sites for the parent resource
         resource.sites.each do |resource_site|
           puts "#{resource_site.id}: #{resource_site.site_code}"
         end
-      end   
+      end
     end
   end
-end  
+end

--- a/lib/tasks/sffamilies.rake
+++ b/lib/tasks/sffamilies.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+namespace :sffamilies do
+  desc('Associate resources to the sffamilies site 
+    if a service from the resource has an sffamilies category tag')
+  task associate_resources: :environment do
+    # Identify the sffamilites site
+    sffamilies = Site.find_by(site_code: 'sffamilies')
+    puts "Site Id: #{sffamilies.id}, Site Code: #{sffamilies.site_code}"
+    
+    Resource.transaction do
+      # Find services that have the 'sffamilies' category name tag
+      services = Service.joins(:categories).where(categories: {name: 'sffamilies'})
+      services.each do |service|
+        
+        puts "Service id : #{service.id} / Service name #{service.name} from Resource id #{service.resource_id} has sffamilies category tag"
+        
+        # Sites are not associated with Services currently
+        # service.sites.each do |service_site|
+        #   puts "#{service_site.id}"
+        # end
+        
+        # If the parent resource of the sffamilies service is not
+        # connected to the site, append the site to it's list
+        resource = Resource.find_by(id: service.id)        
+        unless resource.sites.include?(sffamilies)
+          puts "Adding site association"
+          new_sites = resource.sites.append(sffamilies)
+          Resource.update(resource.id, sites: new_sites)
+        else
+          puts "Site is already associated"
+        end
+
+        # Provide an updated list of the sites for the parent resource
+        resource.sites.each do |resource_site|
+          puts "#{resource_site.id}: #{resource_site.site_code}"
+        end
+      end   
+    end
+  end
+end  


### PR DESCRIPTION
Rake task to link resources to the sffamilies via services that have the sffamilies category tag.
Rake task is idempotent and should have no impact on test data sets after first run.

Testing: run on dev populated data to test (current populate script makes services that have sffamilies category tag but are not connected to the site).

Ticket: https://app.clubhouse.io/sheltertech/story/1709/rake-one-time-task-to-associate-sffamilies-resources-and-services-with-their-site-label

Note: Did not implement sffamilies_exclusive parameters as I have dragged my feet on this ticket for too long.