### PR TITLE
1635: Backfill missing schedules to fix Edit page hanging bug

### DIFF
--- a/lib/tasks/onetime.rake
+++ b/lib/tasks/onetime.rake
@@ -717,4 +717,24 @@ namespace :onetime do
       child_id: child_id
     )
   end
+
+  # Services should always have a corresponding schedule objects, even if they inherit from resource
+  # This task backfills missing schedule objects for some services
+  desc 'Add schedule objects to services that are missing them'
+  task add_missing_schedule_objects: :environment do
+    Schedule.transaction do
+      # Get services with no schedule objects
+      rogue_services = Service.joins('LEFT JOIN schedules '\
+          'ON services.id = schedules.service_id '\
+          'WHERE schedules.id is NULL')
+      rogue_services.each do |service|
+        puts format(
+          'Creating schedule object for service %<service_id>i',
+          service_id: service.service_id
+        )
+        Schedule.create(resource_id: nil, service_id: service.id)
+      end
+      puts format('Created %<num>i missing schedules', num: rogue_services.length)
+    end
+  end
 end


### PR DESCRIPTION
Clubhouse URL: https://app.clubhouse.io/sheltertech/story/1635/editing-certain-organizations-hangs

Added a rake task to backfill missing schedules for services without one.

Before query (194 services missing schedules)
![Screen Shot 2021-01-17 at 3 26 32 PM](https://user-images.githubusercontent.com/8869737/104859300-22cdeb00-58d9-11eb-8a26-d8e0b078fa7b.png)

After query
![Screen Shot 2021-01-17 at 3 26 40 PM](https://user-images.githubusercontent.com/8869737/104859304-2b262600-58d9-11eb-955d-be3a127599d8.png)

A problematic edit page now fixed on local ([same page in staging](https://staging.askdarcel.org/organizations/977/edit))
![Screen Shot 2021-01-17 at 3 26 59 PM](https://user-images.githubusercontent.com/8869737/104859309-38431500-58d9-11eb-800a-bb14bcf627cb.png)

