### PR TITLE
Add a rake task to assign SFFamilies tags

### DIFF
--- a/lib/sffamilies/services_to_tags.csv
+++ b/lib/sffamilies/services_to_tags.csv
@@ -1,0 +1,256 @@
+Project Commotion;PC Schools on the Move!;Sports;Dance;Sports;Special Needs/Disabilities
+Niroga Institute;DMind in Schools;Mental Health Care;Mindfulness;
+Center on Juvenile and Criminal Justice;Expeditor Services;Criminal Justice Involvement;Re-entry Services;
+Catholic Charities;;Criminal Justice Involvement;Mental Health Care;Trauma;Female
+Jewish Community Center of San Francisco;JCCSF Citywide at Sanchez and Alvarado;Afterschool Programs;Fitness & Exercise;
+Collective Impact;Teen Services;Skill Building;Culture & Identity;Tutoring;;
+Visitacion Valley Greenway Community Garden Outdoor Education Program;Visitacion Valley Greenway Community Garden Outdoor Education Program;Afterschool Programs;Summer Programs;Outdoors;
+Community Youth Center of San Francisco (CYC);The API Youth & Family Community Support Services (APIYFCSS);;;
+YMCA of San Francisco - Bayview Hunters Point;;Educational Supports;School Attendance;Tutoring;Case Manager;
+Huckleberry Youth Programs;;Educational Supports;Case Manager;SEL (Social Emotional Learning);
+Mission Neighborhood Resource Center;;Educational Supports;GED/High School Equivalency;English Second Language;GED/High School Equivalency;ESL/ESL/ELL (English Language Learner) (English Language Learner)
+Young Community Developers;;Afterschool Programs;Educational Supports;Summer Programs;Tutoring;college prep;Tutoring;
+Success Center San Francisco;Early Morning Study Academy-GED Preparation & Transitional Services;Educational Supports;GED/High School Equivalency;Criminal Justice Involvement;Skill Building;Daily Life Skills;Job Readiness;GED/High School Equivalency;Foster Youth
+Bay Area Community Resources;A Home Away From Homelessness-Rising Towards College and Career;Educational Supports;Mentoring;Skill Building;Mentoring;Homeless Youth
+Alive & Free;Alive & Free Leadership Academy;Educational Supports;GED/High School Equivalency;Skill Building;College Prep;Leadership;GED/High School Equivalency;
+Breakthrough San Francisco;Year-Round Educational Program for 5 - 12th Grade Youth;Afterschool Programs;College Prep;Educational Supports;Summer Programs;Year-Round;
+Hunters Point Family;Academic Support;Educational Supports;Leadership;
+College Track;College Track San Francisco 2018;College Prep;Educational Supports;Tutoring;Year-Round;Tutoring;College Students
+Booker T. Washington Community Service Center;After School Success;College Prep;Educational Supports;Skill Building;Tutoring;Job Readiness;Leadership;Tutoring;
+Mission Graduates;John O'Connell College and Career Program;College Prep;Educational Supports;;
+Larkin Street Youth Services;Larkin Street Academy;College Prep;Educational Supports;GED/High School Equivalency;Tutoring;GED/High School Equivalency;Tutoring;
+Richmond District Neighborhood Center (RDNC), Inc.;;Afterschool Programs;Educational Supports;Tutoring;Tutoring;
+Samoan Community Development Center;Arise;Educational Supports;;
+San Francisco Students Back On Track;Back On Track 6-12 Free Academic Tutoring;Afterschool Programs;Educational Supports;Mentoring;Tutoring;Tutoring;
+YMCA of San Francisco - Bayview Hunters Point;Center for Academic Re-entry and Empowerment;Alternative Education;School Attendance;;
+Life Learning Academy;Life Learning Academy;Alternative Education;Criminal Justice Involvement;;
+;;Afterschool Programs;Literacy Supports;;
+Springboard Collaborative;Springboard Afterschool and Summer;Literacy Supports;Summer Programs;;
+United Playaz, Inc.;;Literacy Supports;;
+Hunters Point Family;Literacy Supports (G2K/Gilman);Literacy Supports;Tutoring;Tutoring;
+Reading Partners;Literacy Intervention for San Francisco Low-Income Struggling Readers;Literacy Supports;Tutoring;Tutoring;
+826 Valencia;826 Valencia After-School Literacy Program at Buena Vista Horace Mann K-8;Afterschool Programs;Literacy Supports;;
+San Francisco Unified School District;San Francisco Wellness Initiative;Mental Health Care;SFUSD Wellness Centers;Adolescent Health;Stress;Trauma;Suicide;Bullying;Depression;Self-esteem;Substance Abuse Counseling;Sexual & Reproductive Health;Mental Health Care;High School Students
+Handful Players;Handful Players After-School and Summer Performing Arts Program;Afterschool Programs;Arts and Creative Expression;Summer Programs;Performing Arts;Dance;Music;Spoken Word;
+Women's Audio Mission;Girls on the Mic: Media Production & Creative Technology Training for Girls;Afterschool Programs;Arts and Creative Expression;Summer Programs;Mentoring;Mentoring;Music;Digital Arts;
+Oasis For Girls;CREATE;Arts and Creative Expression;Visual Arts;Digital Arts;Performing Arts;Female
+Real Alternatives Program (RAP);;Afterschool Programs;Arts and Creative Expression;Summer Programs;Music;
+Youth Speaks;Arts-in-Education;Arts and Creative Expression;Performing Arts;Spoken Word;
+Community Works West;Community Works Youth Theater Ensemble;Arts and Creative Expression;Dance;Social Justice;
+Sunset Youth Services;Digital Arts and Technology;Afterschool Programs;Arts and Creative Expression;Summer Programs;Digital Arts;Photography and Film;Photography and Film;Year-Round;
+Bay Area Community Resources;Sunset Media Wave;Arts and Creative Expression;Digital Arts;Leadership;
+Jewish Community Center of San Francisco;Afterschool at the JCCSF;Arts and Creative Expression;Culture & Identity;Self-esteem;
+Community Youth Center of San Francisco (CYC);;Arts and Creative Expression;Skill Building;Photography and Film;Music;Daily Life Skills;Leadership;
+Bayview Hunters Point Center for Arts and Technology;Digital Media Pathways Program;Arts and Creative Expression;Digital Arts;Photography and Film;Daily Life Skills;Leadership;
+Youth Art Exchange;Youth Art Exchange After School Arts Program;Afterschool Programs;Arts and Creative Expression;Summer Programs;Performing Arts;Leadership;Visual Arts;High School Students
+New Conservatory Theatre Center;Satellite Drama Education Program;Afterschool Programs;Arts and Creative Expression;Performing Arts;Theater;
+Flyaway Productions;GIRLFLY;Arts and Creative Expression;Summer Programs;Dance;Performing Arts;Self-esteem;
+Performing Arts Workshop;Artists-in-Residency to Support Healthy and Creative Youth;Arts and Creative Expression;Dance;Creative Writing;Music;Performing Arts;Spoken Word;
+Performing Arts Workshop;Streetside Stories - Arts & Creative Expression;Arts and Creative Expression;Creative Writing;Performing Arts;Photography and Film;Storytelling;Visual Arts;
+Queer Women of Color Media Arts Project;Photography and Film & Freedom Academy;Arts and Creative Expression;Mentoring;Photography and Film;Mentoring;Transition Aged Youth (18-24);GED/High School Equivalency
+826 Valencia;Young Author's Publishing Projects;Arts and Creative Expression;Skill Building;Creative Writing;English Second Language;SEL (Social Emotional Learning);ESL/ESL/ELL (English Language Learner) (English Language Learner)
+American Conservatory Theater;Intensive Residencies;Arts and Creative Expression;Performing Arts;Theater;
+The Marsh;Marsh Artists in the Schools;Arts and Creative Expression;Performing Arts;Theater;
+Bindlestiff Studio;;Arts and Creative Expression;Creative Writing;Leadership;Performing Arts;Theater;
+African American Art and Culture Complex;Creative Exploration In the Arts;Arts and Creative Expression;Culture & Identity;Tutoring;;African American
+Brava! for Women in the Arts;MAPA @ Brava;Arts and Creative Expression;Dance;Music;Performing Arts;Theater;Female;LGBTQ
+Project Level;Project Level;Arts and Creative Expression;Music;Dance;Digital Arts;
+Bay Area Video Coalition (BAVC);Media and technology access and training;Arts and Creative Expression;Photography and Film;
+Samoan Community Development Center;Pacific Islander's Rise Up;Arts and Creative Expression;Culture & Identity;;Samoan
+Dance Brigade;Grrrl Brigade;Arts and Creative Expression;Afterschool Programs;Summer Programs;Dance;
+Jamestown Community Center;Loco Bloco Arts Education Programs;Arts and Creative Expression;Performing Arts;Dance;
+Talent All Stars;Talent All Stars, Inc.;Arts and Creative Expression;Performing Arts;Dance;
+ABADA-Capoeira San Francisco;ABADA-Capoeira SF Reaching All Youth Project;Arts and Creative Expression;Performing Arts;Dance;
+Instituto Familiar de La Raza, Inc.;La Cultura Cura Youth Program;Culture & Identity;Tutoring;Self-esteem;Tutoring;Female;Immigrants;Latinx
+Good Samaritan Family Resource Center of San Francisco;Literacy;Culture & Identity;Support Groups;Mentoring;Peer Support;Mentoring;Latinx;Immigrants
+LYRIC Center for LGBTQQ Youth (formerly Lavender Youth Recreation Information Center);School-Based Initiative;Culture & Identity;Support Groups;Self-esteem;Peer Support;LGBTQ
+Mission Neighborhood Centers, Inc.;Youth Development & Leadership;Culture & Identity;Support Groups;Daily Life Skills;Sexual & Reproductive Health;Bullying;Sexual HarassMalet;Peer Support;Female
+Telegraph Hill Neighborhood Center;Futurama;Afterschool Programs;Culture & Identity;;
+Oasis For Girls;RISE;Culture & Identity;Daily Life Skills;Self-esteem;Sexual & Reproductive Health;Female
+Youth Speaks;San Francisco Slam Season;Afterschool Programs;Culture & Identity;Spoken Word;
+Homies Organizing the Mission to Empower Youth (HOMEY);Kalpulli Leadership Program;Culture & Identity;;
+Chinese Progressive Association (CPA), Inc.;;Culture & Identity;Sexual & Reproductive Health;Immigrants
+San Francisco Achievers;High School Support Program;Culture & Identity;Daily Life Skills;SEL (Social Emotional Learning);
+Hunters Point Family;Young Men's Leadership Institute (YMLI);Culture & Identity;Daily Life Skills;Leadership;Male
+Friendship House Association of American Indians;Youth Program;Culture & Identity;;Native American
+Pin@y Educational Partnerships [PEP];;Culture & Identity;Social Justice;Filipino/a
+Charity Cultural Services Center;Family In Transition (FIT);Culture & Identity;Tutoring;Tutoring;ESL/ELL (English Language Learner);Asian
+Mission Science Workshop;Mission Science Workshop;Afterschool Programs;STEM;Summer Programs;;
+Jewish Vocational Services (JVS);Skill Training;STEM;;
+Youth Art Exchange;Youth Art Exchange Rising 9th Grade Summer Architecture & Construction Program;STEM;;
+Mission Bit;Mission Bit San Francisco Coding Education Enhancements;Afterschool Programs;STEM;Summer Programs;Coding;Computer Class;High School Students
+Greater Farallones Association;Oceans Afterschool;Afterschool Programs;STEM;;
+Urban Ed Academy;UEA SMART+ and Focus on Continued Success (Middle School Program);Afterschool Programs;STEM;Mentoring;SEL (Social Emotional Learning);Male
+Edventure More;EDMO Specialty STEAM After School Programs;Afterschool Programs;STEM;SEL (Social Emotional Learning);
+Exploratorium;Afterschool Tinkering Program;Afterschool Programs;Mentoring;STEM;Mentoring;
+CommunityGrows;Seed to Mouth Garden Education Program;STEM;Nature & Gardening;SEL (Social Emotional Learning);
+Life Frames, Inc.;A.L.L. STEAM + Literacy;Afterschool Programs;STEM;Summer Programs;Internships;Nature & Gardening;
+Strategic Energy Innovations;Education Outside;STEM;Nature & Gardening;
+AsianWeek Foundation;Florence Fang Asian Community Garden;STEM;Nature & Gardening;Leadership;
+LYRIC Center for LGBTQQ Youth (formerly Lavender Youth Recreation Information Center);Youth Advocacy;Skill Building;;LGBTQ;Transition Aged Youth (18-24);GED/High School Equivalency
+Japanese Community Youth Council (JCYC);Youth Development Programs;Culture & Identity;Skill Building;;API
+Boys and Girls Club of San Francisco;;Mentoring;Skill Building;Leadership;Job Readiness;Mentoring;
+San Francisco LGBT Community Center;LGBTQ Community Services;Skill Building;Youth Jobs;Leadership;Sexual & Reproductive Health;Trauma Informed;
+Bay Area Community Resources;Hope SF Youth Leadership Program (HSF YPL);Skill Building;Leadership;
+Chinatown Community Development Center (CCDC);;Skill Building;Leadership;Year-Round;Immigrants;Asian;High School Students
+San Francisco Brown Bombers;Brown Bomber Football, Cheer, Dance & Basketball;Sports;Football;Cheer;Basketball;
+Treasure Island Sailing Center;Treasure Island Sailing Center (TISC) - Summer Sailing Camp Progression Program;Sports;Outdoors;
+Jewish Community Center of San Francisco;Citywide Sports and Dance Afterschool Program;Sports;Dance;
+Street Soccer USA;Street Soccer USA - San Francisco;Afterschool Programs;Sports;Soccer;Self-esteem;
+America SCORES Bay Area;America SCORES Soccer Program;Sports;Skill Building;Soccer;
+GirlVentures;GirlVentures' Summer Expeditions: Learning Leadership through Outdoor Sports;Afterschool Programs;Sports;Outdoors;Fitness & Exercise;Female
+Playworks Education Energized;Playworks San Francisco Coach and TeamUp;Sports;SEL (Social Emotional Learning);
+Pomeroy Recreation and Rehabilitation Center (PRRCSF);;Sports;Special Needs/Disabilities;Fitness & Exercise;Disabled
+Mission Youth Soccer League;Mission Youth Soccer League;Sports;Soccer;Year-Round;
+City Surf Project;City Surf Project: Surfing 101 Scholastic Program;Sports;Swimming;Surfing;
+Jamestown Community Center;Girls Got Goals;Sports;Soccer;Female;Latinx;African American
+Jamestown Community Center;Soccer For All;Sports;Soccer;Year-Round;
+Circus Center;Circus Center - Adaptive Circus Enrichment Activities;Afterschool Programs;Arts and Creative Expression;Sports;Performing Arts;Fitness & Exercise;
+Girls on the Run of the Bay Area;Building Healthy, Confident Girls in San Francisco;Sports;Running;Female
+Outward Bound California;Youth Leadership at Outward Bound California's McLaren Park Challenge Course;Sports;Skill Building;Leadership;Outdoors;
+Ultimate Impact;Ultimate Impact - Developing Youth Through Sports;Sports;Ultimate Frisbee;
+EduSkate;EduSkate;Afterschool Programs;Sports;Fitness & Exercise;Middle School Students;High School Students
+Peer Resources;Peer Leaders;Youth Leadership;Mentoring;SEL (Social Emotional Learning);Mentoring;
+Community Works West;Project WHAT!;Youth Leadership;Criminal Justice Involvement;;CIP (Children of Incarcerated Parents)
+Southeast Asian Development Center;Emerging Community Leadership;Youth Leadership;;
+Community Youth Center of San Francisco (CYC);Leadership Development - Bayview Youth Advocates (BYA);Youth Leadership;;
+MyPath;;Youth Leadership;Financial Education;Low-Income
+Larkin Street Youth Services;;Youth Leadership;;
+Filipino Community Center (FCC);Kabataan Youth Leadership Program;Youth Leadership;Afterschool Programs;Daily Life Skills;
+Coleman Advocates for Children and Youth;Youth Making a Change;Youth Leadership;Social Justice;High School Students;Low-Income
+Coro Northern California;Community Action Fellows;Youth Leadership;;
+Youth Leadership Institute;Building Leaders in Innovative New Giving (B.L.I.N.G);Youth-Led Philanthropy;Social Justice;
+Bay Area Community Resources;Youth Funding Youth Ideas;Youth-Led Philanthropy;Social Justice;
+Instituto Familiar de La Raza, Inc.;;Individual Counseling;Family Counseling;Culture & Identity;Job Training;Job Readiness;Job Placement;Latinx
+Young Community Developers;Black to the Future;Individual Counseling;Family Counseling;Culture & Identity;Youth Jobs;;African American
+YMCA of San Francisco - Bayview Hunters Point;Family Resource Center;Family Resource Centers;Support Groups;Maternity Care;
+OMI Family Center;Mental Health Services;Family Resource Centers;Support Groups;Maternity Care;
+Good Samaritan Family Resource Center of San Francisco;Supportive Services;Family Resource Centers;Support Groups;Maternity Care;
+Mission Neighborhood Centers, Inc.;;Family Resource Centers;Support Groups;Maternity Care;
+Portola Family Connections Center;Family Support;Family Resource Centers;Support Groups;Maternity Care;
+GLIDE;Family, Youth, and Childcare Center;Family Resource Centers;Support Groups;Maternity Care;
+;Felton Institute;Family Resource Centers;Support Groups;Maternity Care;
+;Safe & Sound;Family Resource Centers;Support Groups;Maternity Care;
+Community Development;APA Family Support Services;Family Resource Centers;Support Groups;Maternity Care;
+Family Support Center;APA Family Support Services;Family Resource Centers;Support Groups;Maternity Care;
+;Compass Family Services;Family Resource Centers;Support Groups;Maternity Care;
+Family Resource Center;Edgewood Center for Children and Families;Family Resource Centers;Support Groups;Maternity Care;
+;Gum Moon - Chinatown;Family Resource Centers;Support Groups;Maternity Care;
+Prenatal and Parenting Support;Homeless Prenatal Program (HPP);Family Resource Centers;Support Groups;Maternity Care;
+Our Family Coalition;Our Family Coalition;Family Resource Centers;Support Groups;Maternity Care;
+South of Market Child Care, Inc.;South of Market Family Resource Center;Family Resource Centers;Support Groups;Maternity Care;
+Homies Organizing the Mission to Empower Youth (HOMEY);COMMUNITY-BASED STREET INTERVENTION PROGRAM (CALLES);Criminal Justice Involvement;Case Manager;
+Community Works West;Young Men's Reentry;Criminal Justice Involvement;Re-entry Services;Male
+Hunters Point Family;Youth Justice Services;Criminal Justice Involvement;Culture & Identity;Case Manager;
+Legal Services for Children, Inc.;;Family Legal Services;Criminal Justice Involvement;;
+Samoan Community Development Center;Transforming Our Attitude (TOA);Criminal Justice Involvement;Culture & Identity;;Samoan;Transition Aged Youth (18-24);GED/High School Equivalency
+Center on Juvenile and Criminal Justice;CJCJ Juvenile Justice Services (JJS);Criminal Justice Involvement;Case Manager;Re-entry Services;Transition Aged Youth (18-24);GED/High School Equivalency
+Each One Reach One;Pathways to Success;Criminal Justice Involvement;STEM;Re-entry Services;
+Special Service for Groups;Occupational Therapy Training Program-San Francisco;Criminal Justice Involvement;;Female
+Huckleberry Youth Programs;Support for Sexually Exploited Youth;Criminal Justice Involvement;Case Manager;Female;Transition Aged Youth (18-24);GED/High School Equivalency
+Young Women's Freedom Center;Stepping into Sisterhood;Criminal Justice Involvement;;Female;Pregnant
+Community Works West;Women Rising / Rising Voices;Criminal Justice Involvement;Re-entry Services;Female
+University of California, San Francisco                 ;UCSF ZSFG Gender-Responsive Care for Justice-Involved Girls and Young Women;Criminal Justice Involvement;Mental Health Care;Crisis;Trauma Informed;Mental Health Care;Peer Support;Female
+Young Community Developers;Re-entry Services;Criminal Justice Involvement;Mentoring;Mentoring;
+United Playaz, Inc.;In-School Violence Prevention;Skill Building;GED/High School Equivalency;Job Training;Criminal Justice Involvement;Educational Supports;Case Manager;Leadership;Daily Life Skills;Re-entry Services;SEL (Social Emotional Learning);GED/High School Equivalency;Transition Aged Youth (18-24);GED/High School Equivalency
+Sunset Youth Services;Justice Services;Arts and Creative Expression;GED/High School Equivalency;Criminal Justice Involvement;Support Groups;Job Training;Youth Jobs;Crisis;Case Manager;Internships;Parent Education;Re-entry Services;GED/High School Equivalency;Transition Aged Youth (18-24);GED/High School Equivalency
+Bay Area Community Resources;RESET;Criminal Justice Involvement;Re-entry Services;
+Community Youth Center of San Francisco (CYC);Early and Intensive Intervention - Asian Pacific Islander Violence Prevention (APIVPS);Criminal Justice Involvement;Case Manager;SEL (Social Emotional Learning);Transition Aged Youth (18-24);GED/High School Equivalency
+Central American Resource Center (CARECEN);Tattoo Removal Clinic;Culture & Identity;Criminal Justice Involvement;Mental Health Care;Summer Programs;Case Manager;Mental Health Care;Immigrants;Latinx
+Special Service for Groups;OTTP-SF Connective Services Program;Mentoring;Mental Health Care;Mental Health Care;Mentoring;
+Sunset Youth Services;;GED/High School Equivalency;Mentoring;Job Training;Mentoring;Case Manager;Crisis;GED/High School Equivalency;
+University of California, San Francisco                 ;UCSF - Connective Services;Mental Health Care;Mentoring;Criminal Justice Involvement;Trauma Informed;Case Manager;Peer Support;Yoga;Mentoring;Female
+Central American Resource Center (CARECEN);Family Wellness;Mentoring;Support Groups;Summer Programs;Case Manager;Peer Support;Internships;Mentoring;Immigrants;Latinx
+San Francisco CASA;Core Advocacy & Mentoringhip Program for Foster  Youth;Mentoring;Criminal Justice Involvement;Mentoring;Foster Youth
+Westside Community Services;Ajani Program;Mentoring;Case Manager;Mentoring;
+City of Dreams;City of Dreams Youth and TAY Mentoringhip Programs;Mentoring;Mentoring;
+Students Making a Change;Students Making a Change Fellowship Program;Mentoring;Leadership;Peer Support;Mentoring;
+LYRIC Center for LGBTQQ Youth (formerly Lavender Youth Recreation Information Center);;Mentoring;Social Justice;Mentoring;Transition Aged Youth (18-24);GED/High School Equivalency;LGBTQ
+Project Avary;Mentoringhip Project for Children of Incarcerated Parents;Mentoring;Mentoring;CIP (Children of Incarcerated Parents)
+Mission Education Projects Inc.;Reducing the Risk: The Child in Family, School and Community;Educational Supports;Tutoring;Leadership;
+Good Samaritan Family Resource Center of San Francisco;Summer Camps;Culture & Identity;Outdoors;Fitness & Exercise;Latinx
+Good Samaritan Family Resource Center of San Francisco;Vision Academy -- Afterschool;Afterschool Programs;Summer Programs;Outdoors;
+Up on Top;UP ON TOP After-School & Summer Program (SUMMER);Educational Supports;;
+West Bay Filipino Multi-Services Center;Academic Enrichment & Mentorship Program;Afterschool Programs;Tutoring;Mentoring;Summer Programs;SEL (Social Emotional Learning);Fitness & Exercise;Mentoring;Tutoring;
+Indochinese Housing Development Corporation;Tenderloin Achievement Group;Educational Supports;SEL (Social Emotional Learning);
+Telegraph Hill Neighborhood Center;Elementary School Academy (ESA);Afterschool Programs;Summer Programs;STEM;Nature & Gardening;Basketball;
+Portola Family Connections Center;;Afterschool Programs;Tutoring;Summer Programs;Fitness & Exercise;
+Aim High for High School;Aim High for High School;Summer Programs;;
+Bay Area Community Resources;A Home Away From Homelessness;Afterschool Programs;Mentoring;Mentoring;Homeless Youth
+Bay Area Community Resources;BACR Summer Learning;Summer Programs;STEM;Skill Building;SEL (Social Emotional Learning);
+Southeast Asian Development Center;SEA Academic Support Project;Educational Supports;Case Manager;Asian;Immigrants
+Tenderloin Neighborhood Development Corporation (TNDC);;Educational Supports;;
+Seven Tepees Youth Program;Seven Tepees Learning Center;Afterschool Programs;College Prep;Summer Programs;Mentoring;Tutoring;Job Placement;Mentoring;Middle School Students;High School Students;Low-Income
+Potrero Hill Neighborhood House (NABE);;Afterschool Programs;Summer Programs;STEM;Year-Round;
+Buena Vista Child Care;K-8 OST at St. Peter's;Afterschool Programs;Summer Programs;Year-Round;
+Breakthrough San Francisco;Breakthrough Summer Program for Rising Fifth - Eighth Graders;Educational Supports;Summer Programs;Year-Round;
+Edventure More;CAMP EDMO STEAM & SEL (Social Emotional Learning) Day Camps;Summer Programs;STEM;SEL (Social Emotional Learning);Year-Round;
+Hunters Point Family;Gilman;Afterschool Programs;;
+Hunters Point Family;GIRLS 2000;Afterschool Programs;Educational Supports;Tutoring;Daily Life Skills;African American;Female
+Cross Cultural Family Center;;Afterschool Programs;Summer Programs;STEM;;
+Children's After School Arts;CASA (Children's After School Arts);Afterschool Programs;Arts and Creative Expression;;
+Hamilton Families;;Afterschool Programs;Summer Programs;SEL (Social Emotional Learning);Year-Round;
+The Salvation Army Ray & Joan Kroc Corps Community Center;;Afterschool Programs;Summer Programs;SEL (Social Emotional Learning);Year-Round;
+Our Kids First;Our Kids First Out of School Time (OST) Year-Round & Summer Learning;Afterschool Programs;Summer Programs;;
+The Village Project;Out of School Time (OST);Afterschool Programs;Tutoring;Summer Programs;Dance;Financial Education;Soccer;Swimming;Yoga;
+Collective Impact;Magic Zone's Comprehensive Year-Round Program;Afterschool Programs;Tutoring;Summer Programs;STEM;Skill Building;;African American;Low-Income
+Cameron House;Bilingual Afterschool Program;Afterschool Programs;Tutoring;Summer Programs;Leadership;Daily Life Skills;
+Samoan Community Development Center;Pacific Islander Youth Alliance;Afterschool Programs;Summer Programs;;Samoan
+FACES SF;FACES SF K-8 Afterschool Program;Afterschool Programs;Summer Programs;;
+Hearing and Speech Center of Northern California;;Summer Programs;Special Needs/Disabilities;Disabled
+Horizons at the San Francisco Friends School;Horizons at SFFS Summer Enrichment Program;Summer Programs;Fitness & Exercise;Music;Swimming;SEL (Social Emotional Learning);
+Youth First;Youth First After School and Summer Program;Educational Supports;Year-Round;
+Together United Recommitted Forever (TURF);;Mentoring;Mentoring;
+Ingleside Community Center;Ingleside Community Center's After-school Program (ICCAP);Afterschool Programs;Summer Programs;STEM;;
+Asian Pacific American Community Center;Youth Programs;Afterschool Programs;STEM;;
+Bay Area Community Resources;Guadalupe Elementary ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Bay Area Community Resources;Key (Francis Scott) Elementary ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Bay Area Community Resources;Lakeshore Alternative Elementary ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Bay Area Community Resources;Mission Education Center ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Bay Area Community Resources;Serra (Junipero) Elementary ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Bay Area Community Resources;Sherman Elementary ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Bay Area Community Resources;Stevenson (Robert Louis) Elementary ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Bay Area Community Resources;Sunset Elementary ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Bay Area Community Resources;Taylor (Edward R.) Elementary ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Bay Area Community Resources;Ulloa Elementary ExCEL Program;Afterschool Programs;Educational Supports;Fitness & Exercise;Social Justice;
+Mission Graduates;Alvarado Elementary ExCEL Program;Afterschool Programs;;
+Mission Graduates;Marshall Elementary ExCEL Program;Afterschool Programs;;
+Mission Graduates;Cleveland Elementary ExCEL Program;Afterschool Programs;;
+Jamestown Community Center;Longfellow Elementary ExCEL Program;Afterschool Programs;Literacy Supports;Sports;STEM;Tutoring;Dance;Digital Arts;Music;Theater;Tutoring;
+SF ARTS Education;Glen Park Elementary ExCEL Program;Afterschool Programs;;
+Grattan After School Program;Grattan Elementary ExCEL Program;Afterschool Programs;;
+After School Enrichment Program;McKinley Elementary ExCEL Program;Afterschool Programs;Arts and Creative Expression;Educational Supports;Tutoring;Fitness & Exercise;
+After School Enrichment Program;Webster (Daniel) Elementary ExCEL Program;Afterschool Programs;Arts and Creative Expression;Educational Supports;Tutoring;Fitness & Exercise;
+San Francisco Department of Children, Youth and Their Families;Afterschool Meal Program 2019-2020;Afterschool Programs;Food;Food;Food Benefits;
+San Francisco Department of Children, Youth and Their Families;Summer 2019 Meal Program;Food;Summer Programs;Food;Food Benefits;
+Health Initiatives for Youth;WHY Program;Career Awareness;Skill Building;Health Careers;Job Readiness;
+Hunters Point Family;Ujima Urban Agriculture Project;Career Awareness;Nature & Gardening;Job Readiness;
+Spark;Spark Career Exploration & Self-Discovery Program;Career Awareness;;
+First Graduate;First Graduate - First Career;Career Awareness;Immigrants;Job Readiness;Resume Development;
+Japanese Community Youth Council (JCYC);Youth Workforce Programs;Afterschool Programs;Career Awareness;Job Training;Summer Programs;Youth Jobs;Daily Life Skills;Leadership;Job Readiness;Internships;High School Students
+YMCA of San Francisco - Bayview Hunters Point;Primed and Prepped- Youth Workforce Development Program;Youth Jobs;Internships;Job Readiness;Hospitality;Culinary Arts;
+Urban Sprouts;Urban Sprouts;Afterschool Programs;Summer Programs;Youth Jobs;Financial Education;Leadership;Nature & Gardening;
+New Door Ventures;Employment;Educational Supports;Job Training;Youth Jobs;Job Placement;Transition Aged Youth (18-24);GED/High School Equivalency
+Life Learning Academy;LLA Workforce Development Program;Alternative Education;Job Training;Criminal Justice Involvement;;
+Success Center San Francisco;Code on Point - Coding Bootcamp (Formerly Code Ramp);Job Training;STEM;Coding;Computer Class;
+Japanese Community Youth Council (JCYC);;Career Awareness;Job Training;STEM;Job Readiness;Internships;
+Oasis For Girls;ENVISION;Career Awareness;Youth Jobs;Health Careers;Job Readiness;Social Justice;Financial Education;Female
+Juma Ventures;Job-training and placement program;Job Training;Youth Jobs;;Foster Youth;Transition Aged Youth (18-24);GED/High School Equivalency
+San Francisco Conservation Corps (SFCC);Career Pathways;Career Awareness;Educational Supports;Job Training;Youth Jobs;Job Readiness;Transition Aged Youth (18-24);GED/High School Equivalency
+California Academy of Sciences;Careers in Science Internship Program;Career Awareness;College Prep;Job Training;STEM;Youth Jobs;Internships;Job Readiness;Hospitality;Culinary Arts;
+Sunset Youth Services;Workforce Development Program;Job Training;Job Readiness;
+Bay Area Community Resources;Career Pathways Undocumented (CPU);Educational Supports;Youth Jobs;Case Manager;Daily Life Skills;Immigrants;Undocumented
+Bay Area Community Resources;Youthline Tech;Career Awareness;Educational Supports;Job Training;STEM;Youth Jobs;Case Manager;Job Placement;Daily Life Skills;
+Richmond Area Multi-Services;RAMS' NextGen Workforce Program;Career Awareness;Skill Building;Youth Jobs;Case Manager;Job Readiness;Transition Aged Youth (18-24);GED/High School Equivalency
+Jewish Vocational Services (JVS);Youth: 14-24 Connection to postsecondary education or job;Job Training;;Transition Aged Youth (18-24);GED/High School Equivalency
+Jewish Vocational Services (JVS);;Career Awareness;Special Needs/Disabilities;Special Needs/Disabilities;Disabled
+Community Youth Center of San Francisco (CYC);Workforce Development - Job Readiness for English Language Learners (JRELL);Career Awareness;Skill Building;;ESL/ELL (English Language Learner)
+Enterprise for Youth;Pathways;Career Awareness;Job Training;Mentoring;Skill Building;Summer Programs;Financial Education;Internships;Job Readiness;Mentoring;
+Hunters Point Family;Ujamaa Training and Employment;Criminal Justice Involvement;Youth Jobs;Case Manager;Job Placement;Daily Life Skills;
+Old Skool Cafe;Youth Workforce Training and Employment;Skill Building;Youth Jobs;;
+Exploratorium;High School Explainer Program;Summer Programs;Youth Jobs;;High School Students
+Bay Area Video Coalition (BAVC);;Afterschool Programs;STEM;Digital Arts;Photography and Film;
+The ARC;;Career Awareness;Special Needs/Disabilities;Special Needs/Disabilities;Disabled;High School Students
+Jamestown Community Center;Jamestown Community Apprentice Workforce Program;Afterschool Programs;Summer Programs;Youth Jobs;;Disabled
+California Lawyers for the Arts;Spotlight on the Arts;Youth Jobs;;
+San Francisco Unified School District;Early College Student Internship;College Prep;;

--- a/lib/tasks/create_site.rake
+++ b/lib/tasks/create_site.rake
@@ -2,6 +2,9 @@
 
 # Tasks to add default site code of 'sfsg' to all existing resources and categories
 
+require_relative "../../app/models/application_record.rb"
+require_relative "../../app/models/resource_site.rb"
+
 namespace :create_site do
   # create site_code of 'sfsg'
   desc 'Creates a site for sfsg'

--- a/lib/tasks/onetime.rake
+++ b/lib/tasks/onetime.rake
@@ -274,7 +274,6 @@ namespace :onetime do
       sfsg_categories = [
         'Residential Care',
         'Residential Treatment',
-        'Criminal Justice Involvement',
         'Personal Safety Items',
         'Computer or Internet Access',
         'Utilities & Insurance Assistance',
@@ -304,11 +303,10 @@ namespace :onetime do
         'Beacon Community School',
         'SEL (Social Emotional Learning)',
         'Self-esteem',
-        'Trauma informed',
+        'Trauma Informed',
         'Coding',
         'Academic',
         'ELA (English Language Arts)',
-        'Youth Tutoring',
         'Social Justice',
         'Arts and Creative Expression',
         'Creative Writing',
@@ -341,14 +339,33 @@ namespace :onetime do
         'Job Placement',
         'Crisis',
         'Programs Integrated into School Day',
-        'Year-Round'
+        'Year-Round',
+        'Sports',
+        'Summer Programs',
+        'Afterschool Programs',
+        'Literacy Supports',
+        'Educational Supports',
+        'Youth Leadership',
+        'Youth-Led Philanthropy',
+        'Skill Building',
+        'College Prep',
+        'Alternative Education',
+        'School Attendance',
+        'STEM',
+        'Culture & Identity',
+        'Parent Education',
+        'Support Services',
+        'Family Resource Centers',
+        'Family Legal Services',
+        'Youth Jobs',
+        'Basketball'
       ]
       sffamilies_inclusive = [
         'Basic Literacy',
         'English as a Second Language',
         'Computer Class',
         'Foreign Languages',
-        'GED/High-School Equivalency',
+        'GED/High School Equivalency',
         'Preschool',
         'School Supplies',
         'School Transportation',
@@ -435,7 +452,13 @@ namespace :onetime do
         'Scholarship',
         'Shower',
         'Toilet',
-        'Wifi Access'
+        'Wifi Access',
+        'Food',
+        'SFUSD Wellness Centers',
+        'Clothing',
+        'Job Training',
+        'Career Awareness',
+        'Criminal Justice Involvement'
       ]
       # create, then associate each category with a site
       sfsg_categories.each do |c|
@@ -524,6 +547,8 @@ namespace :onetime do
           'In-Home Support' => nil,
           'Independent Living' => nil,
           'Senior Centers' => nil,
+          'Family Resource Centers' => nil,
+          'Support Services' => nil,
           'Adoption & Foster Care' => {
             'Transition Age Youth' => nil,
             'Group Home' => nil
@@ -581,10 +606,12 @@ namespace :onetime do
             'Spiritual Support' => nil
           },
           'Recreation' => {
+            'Sports' => nil,
             'Fitness & Exercise' => nil,
             'Rec Teams' => nil,
             'Cheer' => nil,
             'Football' => nil,
+            'Basketball' => nil,
             'Outdoors' => nil,
             'Soccer' => nil,
             'Swimming' => nil,
@@ -626,6 +653,7 @@ namespace :onetime do
           'Education Financial Assistance' => {
             'Scholarship' => nil
           },
+          'College Prep' => nil,
           'Financial Education' => nil,
           'Preschool' => nil,
           'School Supplies' => nil,
@@ -669,12 +697,19 @@ namespace :onetime do
           },
           'Academic' => {
             'ELA (English Language Arts)' => nil,
+            'Literacy Supports' => nil,
+            'Educational Supports' => nil,
             'Math' => nil,
-            'Youth Tutoring' => nil
+            'STEM' => nil
           },
           'Social Justice' => nil,
+          'Culture & Identity' => nil,
           'Programs Integrated into School Day' => nil,
-          'Year-Round' => nil
+          'Year-Round' => nil,
+          'Summer Programs' => nil,
+          'Afterschool Programs' => nil,
+          'School Attendance' => nil,
+          'Parent Education' => nil
         },
         'Arts and Creative Expression' => {
           'Creative Writing' => nil,
@@ -711,7 +746,12 @@ namespace :onetime do
             'Interview Training' => nil,
             'Resume Development' => nil,
             'Specialized Training' => nil
-          }
+          },
+          'Youth Leadership' => nil,
+          'Youth-Led Philanthropy' => nil,
+          'Youth Jobs' => nil,
+          'Career Awareness' => nil,
+          'Skill Building' => nil
         },
         'Finances & Benefits' => {
           'Childcare Financial Assistance' => nil,
@@ -754,6 +794,7 @@ namespace :onetime do
           'Medical Supplies' => nil,
           'Traumatic Brain Injury' => nil,
           'Vision Care' => nil,
+          'SFUSD Wellness Centers' => nil,
           'Addiction & Recovery' => {
             '12-Step' => nil,
             'Detox' => nil,
@@ -887,7 +928,8 @@ namespace :onetime do
           },
           'Translation & Interpretation' => {
             'English as a Second Language' => nil
-          }
+          },
+          'Family Legal Services' => nil
         },
         'LGBTQ' => nil,
         'MOHCD Funded' => nil,
@@ -958,7 +1000,9 @@ namespace :onetime do
         'Students' => 'High School Students',
         'Teens (13-19 years old)' => 'Teens (13-18 years old)',
         'Transgender' => 'Transgender and Gender Non-Conforming',
-        'Transition Aged Youth' => 'Transition Aged Youth (18-24)'
+        'Transition Aged Youth' => 'Transition Aged Youth (18-24)',
+        'Men' => 'Male',
+        'Women' => 'Female'
       }
       renames.each do |old, new|
         Eligibility.find_by(name: old)&.update(name: new)
@@ -981,7 +1025,8 @@ namespace :onetime do
         'Pacific Islander',
         'CIP (Children of Incarcerated Parents)',
         'ESL/ELL (English Language Learner)',
-        'Special Needs/Disabilities'
+        'Special Needs/Disabilities',
+        'Middle School Students'
       ]
       eligibilities.each do |c|
         Eligibility.find_or_create_by(name: c)

--- a/lib/tasks/sffamilies.rake
+++ b/lib/tasks/sffamilies.rake
@@ -1,32 +1,94 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 namespace :sffamilies do
   desc('Associate resources to the sffamilies site based on service(s) with sffamilies category tag')
-  task associate_resources: :environment do
-    # Identify the sffamilites site
-    sffamilies = Site.find_by(site_code: 'sffamilies')
-    puts "Site Id: #{sffamilies.id}, Site Code: #{sffamilies.site_code}"
+  task associate_resources_with_site: :environment do
+    # Ensure that the sffamilites sites exist
+    Site.transaction do
+      sffamilies = Site.find_or_create_by(site_code: 'sffamilies')
+      puts "Site Id: #{sffamilies.id}, Site Code: #{sffamilies.site_code}"
 
-    Resource.transaction do
-      # Find services that have the 'sffamilies' category name tag
-      services = Service.joins(:categories).where(categories: { name: 'sffamilies' })
-      services.each do |service|
-        puts("Service id : #{service.id}, Service name: #{service.name}" \
-        "from Resource id #{service.resource_id} has sffamilies category tag")
+      Resource.transaction do
+        # Find services that have the 'sffamilies' category name tag
+        services = Service.joins(:categories).where(categories: { name: 'sffamilies' })
+        services.each do |service|
+          puts("Service id : #{service.id}, Service name: #{service.name} " \
+          "from Resource id #{service.resource_id} has sffamilies category tag")
 
-        # If the parent resource of the sffamilies service is not
-        # connected to the site, append the site to it's list
-        resource = Resource.find_by(id: service.id)
-        unless resource.sites.include?(sffamilies)
-          puts "Adding site association"
-          new_sites = resource.sites.append(sffamilies)
-          Resource.update(resource.id, sites: new_sites)
+          # If the parent resource of the sffamilies service is not
+          # connected to the site, append the site to it's list
+          resource = Resource.find_by(id: service.resource_id)
+          unless resource.sites.include?(sffamilies)
+            puts "Adding site association"
+            new_sites = resource.sites.append(sffamilies)
+            Resource.update(resource.id, sites: new_sites)
+          end
+
+          # Provide an updated list of the sites for the parent resource
+          resource.sites.each do |resource_site|
+            puts "#{resource_site.id}: #{resource_site.site_code}"
+          end
+        end
+      end
+    end
+  end
+
+  task assign_tags_to_services: :environment do
+    dirname = 'sffamilies'
+    Service.transaction do
+      # Parse the service to tags map
+      CSV.foreach(File.join('lib', dirname, 'services_to_tags.csv'), \
+                  col_sep: ';') do |row|
+        resource_name = row[0]
+        service_name = row[1]
+        if resource_name.blank? || service_name.blank?
+          # Ignore if these are empty
+          next
         end
 
-        # Provide an updated list of the sites for the parent resource
-        resource.sites.each do |resource_site|
-          puts "#{resource_site.id}: #{resource_site.site_code}"
+        categories_and_eligibilities = row[2..-1]
+        # First identify the resource and service
+        resource = Resource.find_by(name: resource_name)
+        if resource.nil?
+          puts("Resource '#{resource_name}' not found")
+          next
         end
+        service = Service.find_by(name: service_name, resource_id: resource.id)
+        if service.nil?
+          puts("Service '#{service_name}' from resource '#{resource_name}' not found")
+          next
+        end
+        # Then identify the categories and eligibilities
+        new_categories = service.categories
+        new_eligibilities = service.eligibilities
+        categories_and_eligibilities.each do |category_or_eligibility|
+          next if category_or_eligibility.blank?
+
+          # Determine whether this is a category or eligibility
+          found_category = Category.find_by(name: category_or_eligibility)
+          if found_category.nil?
+            found_eligibility = Eligibility.find_by(name: category_or_eligibility)
+            if found_eligibility.nil?
+              warn("Tag '#{category_or_eligibility}' not found in existing data")
+            else
+              # Don't add if the eligibility has already been added
+              new_eligibilities = new_eligibilities.append(found_eligibility) unless new_eligibilities.include?(found_eligibility)
+              # Neither a category nor eligibility, log to stderr
+            end
+          else
+            # Don't add if the category has already been added
+            new_categories = new_categories.append(found_category) unless new_categories.include?(found_category)
+          end
+        end
+        new_categories_str = new_categories.map(&:name)
+        new_eligibilities_str = new_eligibilities.map(&:name)
+        puts("Service: '#{service.name}' (#{service.id})")
+        puts("  * from Resource: '#{resource.name}' (#{resource.id})")
+        puts("  * assigned categories: #{new_categories_str}")
+        puts("  * assigned eligibilities: #{new_eligibilities_str}")
+        Service.update(service.id, categories: new_categories, eligibilities: new_eligibilities)
       end
     end
   end


### PR DESCRIPTION
- Add categories + eligibilities to SFFamilies services.
- Fixed an issue where we were trying to associate sffamilies sites with the wrong resource ids.
- Fixed an "uninitialized constant" error while running the create_site rake tasks.
- Added more tags required by SFFamilies and corrected others.