### PR TITLE
Add site_id to services search endpoint and slightly speed up queries

### DIFF
--- a/app/presenters/resources_lite_presenter.rb
+++ b/app/presenters/resources_lite_presenter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Omit some redundant information while presenting subojects
+# e.g. services.
+class ResourcesLitePresenter < Jsonite
+  property :alternate_name
+  property :certified
+  property :email
+  property :id
+  property :legal_status
+  property :long_description
+  property :name
+  property :short_description
+  property :status
+  property :verified_at
+  property :website
+  property :certified_at
+  property :featured
+  property :source_attribution
+  property :schedule, with: SchedulesPresenter
+  property :phones, with: PhonesPresenter
+  property :addresses, with: AddressPresenter
+  property :notes, with: NotesPresenter
+end

--- a/app/presenters/services_with_resource_lite_presenter.rb
+++ b/app/presenters/services_with_resource_lite_presenter.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ServicesWithResourceLitePresenter < ServicesPresenter
+  property :resource, with: ResourcesLitePresenter
+  property :program, with: ProgramsPresenter
+end

--- a/db/migrate/20210214012211_add_index_to_categories_services.rb
+++ b/db/migrate/20210214012211_add_index_to_categories_services.rb
@@ -1,0 +1,6 @@
+class AddIndexToCategoriesServices < ActiveRecord::Migration[5.2]
+  def change
+    add_index :categories_services, :category_id
+    add_index :categories_services, :service_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_10_052534) do
+ActiveRecord::Schema.define(version: 2021_02_14_012211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,6 +104,8 @@ ActiveRecord::Schema.define(version: 2020_10_10_052534) do
     t.integer "service_id", null: false
     t.integer "category_id", null: false
     t.integer "feature_rank"
+    t.index ["category_id"], name: "index_categories_services_on_category_id"
+    t.index ["service_id"], name: "index_categories_services_on_service_id"
   end
 
   create_table "categories_sites", id: false, force: :cascade do |t|


### PR DESCRIPTION
- Add the ability to filter by site_id to the /services searches (in addition to category / eligibility filters)
- Add `categories_services` indices (tiny speed up)
- Remove redundant / unneeded service data from parent resource nested inside of the service by adding a ResourcesLite presenter (e.g. sibling services - large speed up)

TODO: update Postman docs with site ids in a separate PR. Order the results by number of matching categories.

Query time test results (three consecutive GET requests):
```
http://localhost:3000/services?category_id=1,2,3 (baseline)
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=16672.82 view=1778.09 db=233.27
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=15823.52 view=1800.01 db=189.60
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=15692.25 view=1602.29 db=186.68

adding indices to categories_services
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=15818.43 view=1708.96 db=173.90
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=16009.58 view=1767.81 db=134.33
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=16832.10 view=2002.53 db=137.55

resources lite + indices
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=13121.90 view=437.08 db=90.29
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=12416.46 view=434.68 db=47.13
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=11660.95 view=442.78 db=46.64

resources lite + indices + site
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=13544.64 view=454.95 db=92.69
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=11526.69 view=439.81 db=51.39
api_1      | method=GET path=/services format=html controller=ServicesController action=index status=200 duration=12184.17 view=439.41 db=51.45
```