### PR TITLE
1343 create change request new address

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
   end
   resources :textings, only: %i[create destroy]
   resources :change_requests do
+    post :create
     post :approve
     post :reject
     collection do

--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "8aed082f-4bdf-4fb2-b9c8-6c205a3ad3d2",
+		"_postman_id": "1f00be4c-4f11-4604-be5c-9548c7b31ab4",
 		"name": "AskDarcel API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -11,7 +11,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "786fc94f-9699-4441-9c7a-4afc1e9ed6ea",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Status code is 200\"] = responseCode.code === 200;  "
@@ -51,7 +50,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "fa004c6b-0249-4092-80ae-d9df5b9d2ea6",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 1500ms\"] = responseTime < 1500;",
@@ -111,7 +109,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "7fbba189-81b6-4b82-822e-8d796abf0bbf",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Status code is 200\"] = responseCode.code === 200;  "
@@ -146,7 +143,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "150d44cd-206c-46ee-af1b-646b1343f818",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 1000;",
@@ -341,7 +337,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "24d67b25-9212-4ba0-b40f-afb9ddcdc3f0",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 1000;",
@@ -380,7 +375,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "f846b5d4-6428-4440-b935-735b63907759",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 1000;",
@@ -419,7 +413,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "aadb285c-991c-45bd-8178-2c30489b0bf3",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 200;",
 							"",
@@ -470,8 +463,7 @@
 							"tests[\"Status code is 200\"] = responseCode.code === 200;",
 							"",
 							""
-						],
-						"id": "dad84504-4839-4cd1-9241-8195e6c7e8a2"
+						]
 					}
 				}
 			],
@@ -502,7 +494,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "23ef83fa-4580-4b6b-9fdf-f62be35112ef",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 200;",
@@ -557,7 +548,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "5b67b9f9-12d6-4b8d-a054-b96760ef5fe4",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 200;",
@@ -612,7 +602,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "6c0420e7-2dc5-48f2-97fe-d12a67e9a930",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
@@ -655,7 +644,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "a7d7762e-9edd-4b29-b72a-d04bed652a18",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
@@ -702,7 +690,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "8e310583-1af8-4e24-a2de-aaf9f6b64381",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
@@ -747,7 +734,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "58d50228-8a73-4434-8eac-fa74a3364fc6",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
@@ -800,7 +786,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "b4d2791c-9c04-49ba-9f08-474895a35b48",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
@@ -853,7 +838,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "2cc90a97-896a-43e4-882e-499e825737a1",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 1500ms\"] = responseTime < 1500;",
@@ -926,8 +910,7 @@
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						],
-						"id": "447c8604-442b-4ce8-9793-d62c2386abfd"
+						]
 					}
 				}
 			],
@@ -972,8 +955,7 @@
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						],
-						"id": "219f539c-c486-4179-9c42-802f18652ba7"
+						]
 					}
 				}
 			],
@@ -1018,8 +1000,7 @@
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						],
-						"id": "af7f4656-ce83-4666-b543-71b7f3f04c4c"
+						]
 					}
 				}
 			],
@@ -1064,8 +1045,7 @@
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						],
-						"id": "110722bf-d3ce-4274-b063-ec83534e98b4"
+						]
 					}
 				}
 			],
@@ -1105,13 +1085,12 @@
 				{
 					"listen": "test",
 					"script": {
-						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
 						],
-						"id": "9b206270-f4d1-4c6e-9545-1dc9c8e65ed6"
+						"type": "text/javascript"
 					}
 				}
 			],
@@ -1156,8 +1135,7 @@
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						],
-						"id": "d9336a8c-1695-4c1d-87ab-d7b386f5442b"
+						]
 					}
 				}
 			],
@@ -1197,7 +1175,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "3efaafd8-9d5e-4bb0-9203-6323ebbeeabd",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
@@ -1243,7 +1220,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "c024d34e-8e08-433f-b39e-e385dbf9c3f7",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
@@ -1287,7 +1263,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "174cbea1-40c5-4c52-afe4-926cfc45772e",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
@@ -1331,7 +1306,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "33076515-8d54-4ef0-8a6c-d64b31d755e9",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
@@ -1380,8 +1354,7 @@
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						],
-						"id": "fd11007b-1173-46c2-b02c-587de028090d"
+						]
 					}
 				}
 			],
@@ -1426,8 +1399,7 @@
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						],
-						"id": "0794f536-7736-475f-8ac4-2680f33fd67e"
+						]
 					}
 				}
 			],
@@ -1467,7 +1439,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "09ee3d48-bf31-4249-889a-80f62a3c5dd5",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
@@ -1512,7 +1483,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "f8dd8b8b-73cc-45db-a14a-79eb76f964af",
 						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
@@ -1557,13 +1527,12 @@
 				{
 					"listen": "test",
 					"script": {
-						"type": "text/javascript",
 						"exec": [
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
 						],
-						"id": "214e7bb3-5747-42c9-aa3c-79fa0194966e"
+						"type": "text/javascript"
 					}
 				}
 			],
@@ -1581,7 +1550,93 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{  \n\t\"change_request\": {\n\t\t\"number\": \"(415) 555-5555\",\n\t\t\"service_type\": \"general inquiries\"\n\t},\n\t\"type\": \"phones\",\n\t\"parent_resource_id\": 1\n}"
+					"raw": "{  \n    \"change_request\": {\n        \"action\": \"insert\",\n        \"field_changes\": {\n            \"number\": \"(415) 555-5555\",\n            \"service_type\": \"general inquiries\"\n        }\n    },\n    \"type\": \"phones\",\n    \"parent_resource_id\": 1\n}"
+				},
+				"url": {
+					"raw": "{{base_url}}/change_requests",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"change_requests"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add Address to Resource",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"",
+							"tests[\"Status code is 201\"] = responseCode.code === 201;"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{  \n\t\"change_request\": {\n        \"action\": \"insert\",\n        \"field_changes\": {\n            \"address_1\":\"601 4th Street\",\n            \"city\":\"San Francisco\",\n            \"state_province\":\"CA\",\n            \"country\":\"USA\",\n            \"postal_code\":\"49032\"\n        }\n\t},\n\t\"type\": \"addresses\",\n\t\"parent_resource_id\": 1\n}"
+				},
+				"url": {
+					"raw": "{{base_url}}/change_requests",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"change_requests"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add Address to Resource",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"",
+							"tests[\"Status code is 201\"] = responseCode.code === 201;"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{  \n\t\"change_request\": {\n        \"action\": \"insert\",\n        \"field_changes\": {\n            \"address_1\":\"601 4th Street\",\n            \"city\":\"San Francisco\",\n            \"state_province\":\"CA\",\n            \"country\":\"USA\",\n            \"postal_code\":\"49032\"\n        }\n\t},\n\t\"type\": \"addresses\",\n\t\"parent_resource_id\": 1\n}"
 				},
 				"url": {
 					"raw": "{{base_url}}/change_requests",
@@ -1606,8 +1661,7 @@
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						],
-						"id": "496af2fa-0dd4-4831-8c70-edb7cb3890f8"
+						]
 					}
 				}
 			],
@@ -1650,8 +1704,7 @@
 							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
 							"",
 							"tests[\"Status code is 201\"] = responseCode.code === 201;"
-						],
-						"id": "cc5013cf-c4af-4e99-b84b-c47379dfb7f3"
+						]
 					}
 				}
 			],
@@ -1696,8 +1749,7 @@
 							"tests[\"Response time is less than 12000ms\"] = responseTime < 12000;",
 							"",
 							"tests[\"Status code is 200\"] = responseCode.code === 200;"
-						],
-						"id": "8944a2d4-aa56-40b6-9f11-c46c246723e7"
+						]
 					}
 				}
 			],
@@ -1822,7 +1874,6 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "11c88ac2-34ad-4c75-b789-9396cb10ac90",
 				"type": "text/javascript",
 				"exec": [
 					"var idSchema = {",
@@ -2057,7 +2108,6 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "1b056af4-9609-41f1-b496-16f6f6403ca5",
 				"type": "text/javascript",
 				"exec": [
 					""


### PR DESCRIPTION
Added support for adding a New Address to a Resource through the change_requests endpoint.
Requested are expected to have the required fields to make an address in a 'change_request' hash along with the 'type' of change request and the 'parent_resource_id':
```
{  
  "change_request": {
        "address_1":"601 4th Street",
        "city":"San Francisco",
        "state_province":"CA",
        "country":"USA",
        "postal_code":"49032"
  },
  "type": "addresses",
  "parent_resource_id": 1
}
```
Refactored support code for adding a New Phone to a Resource.
Updated Postman tests to include support for testing 'Add New Address to Resource' ('Add New Phone to Resource' was already supported).
Exposed a route on change_requests to create.

