### PR TITLE
Do not push Docker images for PR builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ after_success:
   - |
     echo Pushing Docker image to Docker Hub
     set -eo pipefail
-    if [[ -n "$TRAVIS_TAG" || "$SANITIZED_BRANCH" == "master" ]]; then
+    if [[ -n "$TRAVIS_TAG" || "$SANITIZED_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
       DOCKER_IMAGE="$REPO:${TRAVIS_TAG:-latest}"
       docker tag localimage "$DOCKER_IMAGE"
       docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"


### PR DESCRIPTION
I think I figured out the root cause of the Travis CI "flakiness" that I was trying to debug in https://github.com/ShelterTechSF/askdarcel-web/pull/1030. It looks like PRs in the askdarcel-api repo build and upload Docker images with the tag `sheltertech/askdarcel-api:latest`, even before they are merged in. You can see https://travis-ci.org/github/ShelterTechSF/askdarcel-api/builds/763781644 as an example of a PR build that uploaded a Docker image. Note that this does not happen to the `push` builds that also happen on PRs.

I guess we kind of messed this up last year in https://github.com/ShelterTechSF/askdarcel-api/pull/497 followed by https://github.com/ShelterTechSF/askdarcel-api/pull/508, but I think the original logic we had, where we checked for `$TRAVIS_PULL_REQUEST == "false"` was more correct than our attempts to fix this. This PR adds that check back in to the `if` expression that guards whether we actually upload a Docker image.