### PR TITLE
Feature: Expose new addresses endpoint for services

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -129,6 +129,18 @@ class ServicesController < ApplicationController
     render json: Service.all.count
   end
 
+  def addresses
+    if params[:service_id] && params[:address_id]
+      service = Service.find params[:service_id]
+      address = Address.find params[:address_id]
+      service.addresses << address
+      service.save!
+      render status: :created, json: { addresses: service.addresses}
+    else
+      render status: :precondition_failed
+    end
+  end
+
   private
 
   def remove_from_algolia(service)

--- a/app/presenters/services_presenter.rb
+++ b/app/presenters/services_presenter.rb
@@ -22,6 +22,6 @@ class ServicesPresenter < Jsonite
   property :schedule, with: SchedulesPresenter
   property :notes, with: NotesPresenter
   property :categories, with: CategoryPresenter
-  # property :addresses, with: AddressPresenter
+  property :addresses, with: AddressPresenter
   property :eligibilities, with: EligibilityPresenter
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     post :approve
     post :reject
     post :certify
+    post :addresses
     collection do
       get :featured
       get :pending

--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "1f00be4c-4f11-4604-be5c-9548c7b31ab4",
+		"_postman_id": "04d60024-7618-4f3a-9257-15c0b6ff3958",
 		"name": "AskDarcel API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -181,7 +181,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "27b25cdd-5e05-4709-9fac-94a0e15c53a7",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 2000;",
 							"",
@@ -220,7 +219,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "3097519a-6085-408d-8250-08e3f2185fee",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 2000;",
 							"",
@@ -259,7 +257,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "9f97aeb5-5a84-43a7-bc36-c995f4147e17",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 2000;",
 							"",
@@ -298,7 +295,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "d7cfa5be-cc21-4c19-8201-033c721da8f2",
 						"exec": [
 							"tests[\"Response time is less than 200ms\"] = responseTime < 2000;",
 							"",
@@ -1389,6 +1385,57 @@
 			"response": []
 		},
 		{
+			"name": "Add Address to Service",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"",
+							"tests[\"Status code is 201\"] = responseCode.code === 201;"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{base_url}}/services/1/addresses?address_id=1",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"services",
+						"1",
+						"addresses"
+					],
+					"query": [
+						{
+							"key": "address_id",
+							"value": "1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Add Note to Resource",
 			"event": [
 				{
@@ -1792,7 +1839,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "9fee45c6-9d64-40ba-83b3-68d78c4ac757",
 						"exec": [
 							"pm.test(\"Sending Empty Phone Number\", function () {",
 							"    const responseJson = pm.response.json();",
@@ -1835,7 +1881,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "8d75a5ae-4603-41e9-99d7-728b58a1001d",
 						"exec": [
 							"pm.test(\"Sending with a phone number\", function () {",
 							"    pm.response.to.have.status(200);",
@@ -2114,6 +2159,5 @@
 				]
 			}
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }


### PR DESCRIPTION
Changes:
- Add route at /services/:service_id/addresses?address_id=:address_id to associate a service and address
- Post requires no params in the body
- Post fails if address or service do not exist 
- Added postman tests

Concerns:
- currently can associate a service to an address multiple times
