### PR TITLE
Update rails defaults for DB connection in dev

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -24,7 +24,7 @@ default: &default
 development:
   <<: *default
   database: askdarcel_development
-  url: <%= ENV['DATABASE_URL'] %>
+  url: <%= ENV['DATABASE_URL'] || 'postgres://postgres@localhost/askdarcel_development' %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -59,7 +59,7 @@ development:
 test:
   <<: *default
   database: askdarcel_test
-  url: <%= ENV['TEST_DATABASE_URL'] %>
+  url: <%= ENV['TEST_DATABASE_URL'] || 'postgres://postgres@localhost/askdarcel_test' %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     image: "postgres:9.5"
     networks:
       - askdarcel
+    ports:
+      - "5432:5432"
 
   api:
     build:


### PR DESCRIPTION
This change just exposes the postgres DB through localhost and updates rails to be able to find it if you don't have the other DB env variabbles set.

This allows me to do stuff like 
`bundle exec rails swagger` from my host and it uses the dockerized postgres DB to run.