### PR TITLE
513 Implemented a HSDS compliant organization API

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,0 +1,31 @@
+class OrganizationsController < ApplicationController
+    '''Organizations Controller. Key names changed to be HSDS compliant'''
+    def index
+        organization = Resource.order(:name)
+        # push elements into list to meet formatting requirements for HSDS 
+        organization_container = []
+        organization.each do |element|
+            organization_container.push(element)
+        end
+        render json: OrganizationsPresenter.present(organization_container)
+    end
+    def show
+        # Find the relevant resource and adjust variables for HSDS form
+        resource = Resource.find([params[:id]])
+        
+        render json: OrganizationsPresenter.present(resource)
+    end
+    
+    def destroy
+        org = Resource.find params[:id]
+        org.delete
+    end
+    
+    def organization
+        # Note: We *must* use #preload instead of #includes to force Rails to make a
+        # separate query per table. Otherwise, it creates one large query with many
+        # joins, which amplifies the amount of data being sent between Rails and the
+        # DB by several orders of magnitude due to duplication of tuples.
+        Resource.preload(:resources)
+    end
+end

--- a/app/presenters/organizations_presenter.rb
+++ b/app/presenters/organizations_presenter.rb
@@ -1,0 +1,12 @@
+class OrganizationsPresenter < Jsonite
+  property :id
+  property :name
+  property :alternate_name
+	property(:description) { long_description }
+  property :email
+  property(:url) { website }
+  property(:tax_status){ nil }
+  property(:tax_id){ nil }
+  property(:year_incorporated){ nil }
+  property :legal_status
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       get :counts
       get :featured
       get :subcategories
+      get :hierarchy
     end
   end
   resources :eligibilities, only: %i[index show update] do
@@ -25,14 +26,14 @@ Rails.application.routes.draw do
     post :create
     post :certify
 
-    resources :ratings, only: :create
     resources :change_requests, only: :create
     resources :services, only: :create
+    resources :feebacks, only: %i[create index]
   end
   resources :services do
-    resources :ratings, only: :create
     resources :change_requests, only: :create
     resources :notes, only: :create
+    resources :feedbacks, only: %i[create index]
     post :approve
     post :reject
     post :certify

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
       get :counts
       get :featured
       get :subcategories
-      get :hierarchy
     end
   end
   resources :eligibilities, only: %i[index show update] do
@@ -26,14 +25,14 @@ Rails.application.routes.draw do
     post :create
     post :certify
 
+    resources :ratings, only: :create
     resources :change_requests, only: :create
     resources :services, only: :create
-    resources :feedbacks, only: %i[create index]
   end
   resources :services do
+    resources :ratings, only: :create
     resources :change_requests, only: :create
     resources :notes, only: :create
-    resources :feedbacks, only: %i[create index]
     post :approve
     post :reject
     post :certify
@@ -44,6 +43,9 @@ Rails.application.routes.draw do
     end
   end
   resources :notes do
+    resources :change_requests, only: :create
+  end
+  resources :organizations do
     resources :change_requests, only: :create
   end
   resources :addresses do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
   resources :services do
     resources :change_requests, only: :create
     resources :notes, only: :create
-    resources :feedbacks, only: %i[create index]
+    resources :feedback, only: %i[create index]
     post :approve
     post :reject
     post :certify

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,12 +28,12 @@ Rails.application.routes.draw do
 
     resources :change_requests, only: :create
     resources :services, only: :create
-    resources :feebacks, only: %i[create index]
+    resources :feedbacks, only: %i[create index]
   end
   resources :services do
     resources :change_requests, only: :create
     resources :notes, only: :create
-    resources :feedback, only: %i[create index]
+    resources :feedbacks, only: %i[create index]
     post :approve
     post :reject
     post :certify

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -1590,6 +1590,110 @@
           "application/json"
         ]
       }
+    },
+
+    "/phones/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "examples": {
+              "application/json": {
+                    "id": "string",
+                    "number": "string",
+                    "extension": "string",
+                    "service_type": "string",
+                    "country_code": "string"
+              }
+            },
+            "description": "Phone Response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "integer",
+            "description": "Phone ID",
+            "required": true
+          }
+        ],
+        "tags": [
+          "phones"
+        ],
+        "summary": "Retrieves phone numbers by id",
+        "produces" : [
+          "application/json"
+        ]
+      }
+    },
+    "/organizations": {
+      "get": {
+        "responses": {
+          "200": {
+            "examples": {
+              "application/json": {
+                "id": "string",
+                "name": "string",
+                "alternate_name": "string",
+                "description": "string",
+                "email": "string",
+                "url": "string",
+                "tax_status": "string",
+                "tax_id": "string",
+                "year_incorporated": "string",
+                "legal_status": "string"
+              }
+            },
+            "description": "Organization Response"
+          }
+        },
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Retrieves all organizations",
+        "produces" : [
+          "application/json"
+        ]
+      }
+    },
+    "/organizations/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "examples": {
+              "application/json": {
+                "id": "string",
+                "name": "string",
+                "alternate_name": "string",
+                "description": "string",
+                "email": "string",
+                "url": "string",
+                "tax_status": "string",
+                "tax_id": "string",
+                "year_incorporated": "string",
+                "legal_status": "string"
+              }
+            },
+            "description": "Organization Response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "integer",
+            "description": "Resource ID",
+            "required": true
+          }
+        ],
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Retrieves organization by id",
+        "produces" : [
+          "application/json"
+        ]
+      }
     }
   }
 }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -1591,41 +1591,6 @@
         ]
       }
     },
-
-    "/phones/{id}": {
-      "get": {
-        "responses": {
-          "200": {
-            "examples": {
-              "application/json": {
-                    "id": "string",
-                    "number": "string",
-                    "extension": "string",
-                    "service_type": "string",
-                    "country_code": "string"
-              }
-            },
-            "description": "Phone Response"
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "type": "integer",
-            "description": "Phone ID",
-            "required": true
-          }
-        ],
-        "tags": [
-          "phones"
-        ],
-        "summary": "Retrieves phone numbers by id",
-        "produces" : [
-          "application/json"
-        ]
-      }
-    },
     "/organizations": {
       "get": {
         "responses": {


### PR DESCRIPTION
I implemented the solution to Issue 513. This required creating a new API for organizations. Organizations are very similar to resources, but feature the `description` key instead of `long-description` or `short-description` and `url` instead of `website`. I achieved this by writing a controller for organizations that used a special presenter. The presenter merely rewrapped resource objects in an HSDS compliant manner. I added this change to the swagger api-docs as well. 