### PR TITLE
Remove Association between Address and Service

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,21 +1,47 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/MethodLength
 class AddressesController < ApplicationController
   def update
     service = Service.find_by_id(params[:service_id])
     address = Address.find_by_id(params[:id])
     if service && address
-      if service.addresses.include?(address)
-        render status: :ok
-      else
-        service.addresses << address
-        service.save!
-        render status: :created
-      end
+      add_address_to_service(service, address)
+      return
     else
       render status: :bad_request
     end
   end
+
+  def destroy
+    service = Service.find_by_id(params[:service_id])
+    address = Address.find_by_id(params[:id])
+    if service && address
+      remove_address_from_service(service, address)
+      return
+    else
+      render status: :bad_request
+    end
+  end
+
+  private
+
+  def add_address_to_service(service, address)
+    if service.addresses.include?(address)
+      render status: :ok
+    else
+      service.addresses << address
+      service.save!
+      render status: :created
+    end
+  end
+
+  def remove_address_from_service(service, address)
+    if service.addresses.include?(address)
+      service.addresses.delete(address)
+      service.save!
+      render status: :no_content
+    else
+      render status: :ok
+    end
+  end
 end
-# rubocop:enable Metrics/MethodLength

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/MethodLength
 class AddressesController < ApplicationController
   def update
     service = Service.find_by_id(params[:service_id])
     address = Address.find_by_id(params[:id])
     if service && address
-      add_address_to_service(service, address)
-      return
+      if service.addresses.include?(address)
+        render status: :ok
+      else
+        service.addresses << address
+        service.save!
+        render status: :created
+      end
     else
       render status: :bad_request
     end
@@ -16,32 +22,15 @@ class AddressesController < ApplicationController
     service = Service.find_by_id(params[:service_id])
     address = Address.find_by_id(params[:id])
     if service && address
-      remove_address_from_service(service, address)
-      return
+      if service.addresses.include?(address)
+        service.addresses.delete(address)
+        render status: :no_content
+      else
+        render status: :ok
+      end
     else
       render status: :bad_request
     end
   end
-
-  private
-
-  def add_address_to_service(service, address)
-    if service.addresses.include?(address)
-      render status: :ok
-    else
-      service.addresses << address
-      service.save!
-      render status: :created
-    end
-  end
-
-  def remove_address_from_service(service, address)
-    if service.addresses.include?(address)
-      service.addresses.delete(address)
-      service.save!
-      render status: :no_content
-    else
-      render status: :ok
-    end
-  end
 end
+# rubocop:enable Metrics/MethodLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
     resources :change_requests, only: :create
     resources :notes, only: :create
     resources :feedbacks, only: %i[create index]
-    resources :addresses, only: :update
+    resources :addresses, only: %i[update destroy]
     post :approve
     post :reject
     post :certify

--- a/postman/AskDarcel%20API.postman_collection.json
+++ b/postman/AskDarcel%20API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b0fc3937-a87a-4eb4-a177-657622f497a5",
+		"_postman_id": "f002431c-1890-41c6-a302-80b93abb86db",
 		"name": "AskDarcel API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1401,6 +1401,52 @@
 			],
 			"request": {
 				"method": "PUT",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{base_url}}/services/15/addresses/11",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"services",
+						"15",
+						"addresses",
+						"11"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Remove Address From Service",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"tests[\"Response time is less than 1000ms\"] = responseTime < 1000;",
+							"",
+							"tests[\"Status code is 204\"] = responseCode.code === 204;"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
 				"header": [
 					{
 						"key": "Accept",


### PR DESCRIPTION
Added a #destroy method to the Addresses Controller.
Followed convention with other DELETE requests in the Api.
