### PR TITLE
Fix service endpoint returning 500s (missing rating table)

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -221,8 +221,7 @@ class ServicesController < ApplicationController
       .includes(
         resource: [
           :addresses, :phones, :categories, :notes,
-          schedule: :schedule_days,
-          ratings: [:review]
+          schedule: :schedule_days
         ]
       )
   end


### PR DESCRIPTION
The SFFamilies service endpoint is currently serving 500s due to a missing ratings table expected by the services with resource presenter.

(Postman CI tests didn't catch this cause the existing tests in the AskDarcel API section for get services by categories are bogus, the ShelterTech_Data readonly api endpoint tests need to get copied over or also ran in CI.)