### PR TITLE
Partial revert of 8f1a575c9b11f987578342bfbbe02063373863e7

### DIFF
--- a/app/presenters/services_presenter.rb
+++ b/app/presenters/services_presenter.rb
@@ -22,6 +22,6 @@ class ServicesPresenter < Jsonite
   property :schedule, with: SchedulesPresenter
   property :notes, with: NotesPresenter
   property :categories, with: CategoryPresenter
-  # property :addresses, with: AddressPresenter
+  property :addresses, with: AddressPresenter
   property :eligibilities, with: EligibilityPresenter
 end


### PR DESCRIPTION
For some reason we commented out addresses in the ServicesPresenter in 8f1a575c9b11f987578342bfbbe02063373863e7. This prevents the multiple addresses for services feature from working, so I am partially reverting that commit.