### PR TITLE
Bump Node.js to 16.x.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   RUBY_VERSION: 2.7
-  NODE_VERSION: 10.x
+  NODE_VERSION: 16.x
   RAILS_ENV: test
   TEXTELLENT_AUTH_CODE: ${{ secrets.TEXTELLENT_AUTH_CODE }}
   DOCKER_REPO: sheltertechsf/askdarcel-api


### PR DESCRIPTION
We were previously using 10, which was way EOL, and it was causing newer
installations of newman to fail because it was too old.