### PR TITLE
Update Postgres Client package to 13. 9.5 Doesnt seem to exist anymor…

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,9 +2,10 @@ FROM ruby:2.7.4
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-   apt-get update && \
-   apt-get install -y postgresql-client-9.5 && \
+   apt-get update && apt list -a postgresql-client && \
+   apt-get install -y postgresql-client-13 && \
    rm -rf /var/lib/apt/lists/*
+
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,10 +2,9 @@ FROM ruby:2.7.4
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-   apt-get update && apt list -a postgresql-client && \
+   apt-get update && \
    apt-get install -y postgresql-client-13 && \
    rm -rf /var/lib/apt/lists/*
-
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 

--- a/app/jobs/algolia_reindex_job.rb
+++ b/app/jobs/algolia_reindex_job.rb
@@ -17,8 +17,6 @@ class AlgoliaReindexJob
     Resource.where(status: :approved).reindex
 
     # Batch synonyms, with replica forwarding and atomic replacement of existing synonyms
-    forward_to_replicas = true
-    replace_existing_synonyms = true
     Resource.index.save_synonyms(format_synonyms_list, { forwardToReplicas: true, replaceExistingSynonyms: true })
 
     # Since Service and Resource share an algolia index, we use `reindex!` so

--- a/app/jobs/algolia_reindex_job.rb
+++ b/app/jobs/algolia_reindex_job.rb
@@ -19,7 +19,7 @@ class AlgoliaReindexJob
     # Batch synonyms, with replica forwarding and atomic replacement of existing synonyms
     forward_to_replicas = true
     replace_existing_synonyms = true
-    Resource.index.batch_synonyms(format_synonyms_list, forward_to_replicas, replace_existing_synonyms)
+    Resource.index.save_synonyms(format_synonyms_list, { forwardToReplicas: true, replaceExistingSynonyms: true })
 
     # Since Service and Resource share an algolia index, we use `reindex!` so
     # Service reindexing does not clear out Resource index records.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
-    image: "postgres:13"
+    image: "postgres:9.5"
     networks:
       - askdarcel
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
-    image: "postgres:9.5"
+    image: "postgres:13"
     networks:
       - askdarcel
     ports:

--- a/lib/sheltertech/db/staging_importer.rb
+++ b/lib/sheltertech/db/staging_importer.rb
@@ -24,8 +24,8 @@ module ShelterTech
       def self.import_staging_database!(password)
         local_db_config = ActiveRecord::Base.connection_config
 
-        staging_config = local_db_config.clone
-        staging_config[:host] = 'staging-db.askdarcel.org'
+        staging_config = local_db_config.deep_dup
+        staging_config[:host] = '35.197.79.154'
         staging_config[:database] = 'askdarcel'
         staging_config[:username] = 'master'
         staging_config[:password] = password

--- a/spec/jobs/algolia_reindex_job_spec.rb
+++ b/spec/jobs/algolia_reindex_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Algolia Reindex Job' do
 
     resource_index = double
     expect(Resource).to receive(:index).and_return(resource_index)
-    expect(resource_index).to receive(:batch_synonyms)
+    expect(resource_index).to receive(:save_synonyms)
 
     service_query = double
     expect(Service).to receive(:where).with(status: :approved).and_return(service_query)


### PR DESCRIPTION
…e. Replace deprecated algolia index method batch_snynoyms. Update staging DB hostname.

I set up the API environment on my new comp and ran into some of these issues while creating the Docker build and importing the staging DB. Looks like we're quite behind with our Postgres Client version. We're also using deprecated Algolia index methods. We also need to do a deep clone of the local db config object (as `.clone` just creates a pointer to the hash reference, which Rails considers a frozen hash). And lastly, I had to update the hostname of the staging API to the correct IP as `staging-db.askdarcel.org` points to the wrong one.