### PR TITLE
Make Debian version match between Docker base image and PostgreSQL apt repository.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
-FROM ruby:2.7.4
+FROM ruby:2.7.6-buster
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
    apt-get update && \
    apt-get install -y postgresql-client-13 && \


### PR DESCRIPTION
Having these be mismatched may cause packages to not be found. The
official Ruby images provide multiple versions of Debian for the same
Ruby version, so here we pin the Debian version to Buster (the latest
supported by Ruby 2.7) and make sure the PostgreSQL package matches.

This works for my Intel-based Mac, but someone with an M1 should confirm that this works for them as well so that we stop ping-ponging back and forth between breaking stuff on the other architecture.