### PR TITLE
Include documents when fetching services

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -218,7 +218,7 @@ class ServicesController < ApplicationController
   end
 
   def services
-    Service.includes(:notes, :categories, :eligibilities, :addresses, schedule: :schedule_days)
+    Service.includes(:notes, :categories, :eligibilities, :addresses, :documents, schedule: :schedule_days)
   end
 
   # Clean raw request params for interoperability with Rails APIs.

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class DocumentPresenter < Jsonite
+  property :id
+  property :url
+  property :name
+  property :description
+end

--- a/app/presenters/services_presenter.rb
+++ b/app/presenters/services_presenter.rb
@@ -25,4 +25,5 @@ class ServicesPresenter < Jsonite
   property :addresses, with: AddressPresenter
   property :eligibilities, with: EligibilityPresenter
   property :instructions, with: InstructionsPresenter
+  property :documents, with: DocumentPresenter
 end

--- a/db/migrate/20220825045308_create_table_documents_services.rb
+++ b/db/migrate/20220825045308_create_table_documents_services.rb
@@ -1,0 +1,8 @@
+class CreateTableDocumentsServices < ActiveRecord::Migration[6.1]
+    def change
+      create_table :documents_services, :id => false do |t|
+        t.integer :service_id
+        t.integer :document_id
+      end
+    end
+  end

--- a/db/migrate/20220825045308_create_table_service_documents.rb
+++ b/db/migrate/20220825045308_create_table_service_documents.rb
@@ -1,8 +1,0 @@
-class CreateTableServiceDocuments < ActiveRecord::Migration[6.1]
-  def change
-    create_table "service_documents", :id => false do |t|
-      t.integer :service_id
-      t.integer :document_id
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -165,6 +165,11 @@ ActiveRecord::Schema.define(version: 2022_09_02_003134) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "documents_services", id: false, force: :cascade do |t|
+    t.integer "service_id"
+    t.integer "document_id"
+  end
+
   create_table "eligibilities", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -335,11 +340,6 @@ ActiveRecord::Schema.define(version: 2022_09_02_003134) do
     t.boolean "hours_known", default: true
     t.index ["resource_id"], name: "index_schedules_on_resource_id"
     t.index ["service_id"], name: "index_schedules_on_service_id"
-  end
-
-  create_table "service_documents", id: false, force: :cascade do |t|
-    t.integer "service_id"
-    t.integer "document_id"
   end
 
   create_table "services", force: :cascade do |t|

--- a/lib/sheltertech/db/fixture_populator.rb
+++ b/lib/sheltertech/db/fixture_populator.rb
@@ -230,16 +230,12 @@ module ShelterTech
         document = FactoryBot.create(:document,
                                      name: service.id.to_s, url: "document_url",
                                      description: "Some document")
-        service_document = ServiceDocument.new
-        service_document.service = service
-        service_document.document = document
-        service_document.save
+        service.documents << document
 
         instruction = Instruction.new
         instruction.service = service
         instruction.instruction = "Instruction text goes here"
         service.instructions << instruction
-
         FactoryBot.create(:change_request,
                           type: 'ResourceChangeRequest',
                           status: ChangeRequest.statuses[:pending],


### PR DESCRIPTION
Manually tested on local rails app, able to see the documents associated with a service as part of the services output:
http://localhost:3000/services/1 =>
`documents":[{"id":1,"url":"document_url"}]`

Note: The above output isn't the full output, i just grabbed the part which displays the documents.