### PR TITLE
Use focal postgres package rather than xenial as xenial is no longer …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   RAILS_ENV: test
   TEXTELLENT_AUTH_CODE: ${{ secrets.TEXTELLENT_AUTH_CODE }}
   DOCKER_REPO: sheltertechsf/askdarcel-api
+  TEST_TAG: sheltertechsf/test:test
 
 jobs:
   lint:
@@ -66,7 +67,6 @@ jobs:
   publish-latest:
     runs-on: ubuntu-latest
     needs: [lint, test_unit, test_postman]
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -78,5 +78,4 @@ jobs:
       - uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ env.DOCKER_REPO }}:latest
-      - run: echo ${{ steps.docker_build.outputs.digest }}
+          tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ env:
   RAILS_ENV: test
   TEXTELLENT_AUTH_CODE: ${{ secrets.TEXTELLENT_AUTH_CODE }}
   DOCKER_REPO: sheltertechsf/askdarcel-api
-  TEST_TAG: sheltertechsf/test:test
 
 jobs:
   lint:
@@ -67,6 +66,7 @@ jobs:
   publish-latest:
     runs-on: ubuntu-latest
     needs: [lint, test_unit, test_postman]
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -78,4 +78,5 @@ jobs:
       - uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ env.TEST_TAG }}
+          tags: ${{ env.DOCKER_REPO }}:latest
+      - run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM ad2games/docker-rails:2.8.5
 # http://askubuntu.com/questions/383339/how-to-recover-deleted-dpkg-directory
 # forward request and error logs to docker log collector
 
+# NB The xenial-pgdg package that we're installing with APT below may be removed from Postgres' repo
+# when future Linux updates come out. See: https://wiki.postgresql.org/wiki/Apt for updates.
+
 RUN mkdir -p /var/lib/dpkg/alternatives /var/lib/dpkg/info /var/lib/dpkg/parts /var/lib/dpkg/triggers /var/lib/dpkg/updates && \
   touch /var/lib/dpkg/status && \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ad2games/docker-rails:2.8.5
 
 # ad2games/docker-rails removes files required for dpkg to work. We must
-# recreate those files first before we can in stall postgresql-client.
+# recreate those files first before we can install postgresql-client.
 # See this StackExchange question on restoring dpkg files:
 # http://askubuntu.com/questions/383339/how-to-recover-deleted-dpkg-directory
 # forward request and error logs to docker log collector
@@ -11,7 +11,7 @@ RUN mkdir -p /var/lib/dpkg/alternatives /var/lib/dpkg/info /var/lib/dpkg/parts /
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   mv /home/app/webapp/config/appserver.sh /etc/service/appserver/run && \
   chmod 777 /etc/service/appserver/run && \
-  echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
+  echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
   curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
   apt-get update && \
   apt-get install -y libglib2.0-dev && \


### PR DESCRIPTION
…supported.

Apparently we have been installing a Postgres package from an outdated version of linux for some time now. Postgres removed the package from their apt repo (https://wiki.postgresql.org/wiki/Apt) about a week ago, so our `publish-latest` builds have been failing since. This PR updates our Dockerfile to install the package from a newer repo (using Focal), which is the OS that our base Docker images are using. I tested the job [here](https://github.com/ShelterTechSF/askdarcel-api/actions/runs/3147092778/jobs/5116270033) by temporarily altering our `publish-latest` job to use a test tag, alongside the update to the Dockerfile