### PR TITLE
Add status to service presenter.

### DIFF
--- a/app/presenters/services_presenter.rb
+++ b/app/presenters/services_presenter.rb
@@ -19,6 +19,7 @@ class ServicesPresenter < Jsonite
   property :certified_at
   property :featured
   property :source_attribution
+  property :status
   property :schedule, with: SchedulesPresenter
   property :notes, with: NotesPresenter
   property :categories, with: CategoryPresenter


### PR DESCRIPTION
Including this prop so that the frontend can perform a redirect on service listing pages where the service is deactivated.