### PR TITLE
Update news articles table

### DIFF
--- a/app/presenters/news_article_presenter.rb
+++ b/app/presenters/news_article_presenter.rb
@@ -7,4 +7,5 @@ class NewsArticlePresenter < Jsonite
   property :body
   property :priority
   property :expiration_date
+  property :url
 end

--- a/db/migrate/20230404181143_add_url_to_news_articles.rb
+++ b/db/migrate/20230404181143_add_url_to_news_articles.rb
@@ -1,0 +1,5 @@
+class AddUrlToNewsArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :news_articles, :url, :string
+  end
+end

--- a/db/migrate/20230404230604_drop_news_article.rb
+++ b/db/migrate/20230404230604_drop_news_article.rb
@@ -1,0 +1,5 @@
+class DropNewsArticle < ActiveRecord::Migration[6.1]
+  def change
+   drop_table(:news_article, if_exists: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -353,15 +353,6 @@ ActiveRecord::Schema.define(version: 2023_04_04_230604) do
     t.index ["service_id"], name: "index_schedules_on_service_id"
   end
 
-  create_table "service_at_locations", force: :cascade do |t|
-    t.bigint "service_id"
-    t.bigint "address_id"
-    t.bigint "schedule_id"
-    t.index ["address_id"], name: "index_service_at_locations_on_address_id"
-    t.index ["schedule_id"], name: "index_service_at_locations_on_schedule_id"
-    t.index ["service_id"], name: "index_service_at_locations_on_service_id"
-  end
-
   create_table "services", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_09_212858) do
+ActiveRecord::Schema.define(version: 2023_04_04_181143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -261,6 +261,7 @@ ActiveRecord::Schema.define(version: 2022_09_09_212858) do
     t.datetime "expiration_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "url"
   end
 
   create_table "notes", force: :cascade do |t|
@@ -360,6 +361,11 @@ ActiveRecord::Schema.define(version: 2022_09_09_212858) do
     t.boolean "hours_known", default: true
     t.index ["resource_id"], name: "index_schedules_on_resource_id"
     t.index ["service_id"], name: "index_schedules_on_service_id"
+  end
+
+  create_table "service_documents", id: false, force: :cascade do |t|
+    t.integer "service_id"
+    t.integer "document_id"
   end
 
   create_table "services", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_04_181143) do
+ActiveRecord::Schema.define(version: 2023_04_04_230604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -243,16 +243,6 @@ ActiveRecord::Schema.define(version: 2023_04_04_181143) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "news_article", force: :cascade do |t|
-    t.string "headline"
-    t.datetime "effective_date"
-    t.string "body"
-    t.integer "priority"
-    t.datetime "expiration_date"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "news_articles", force: :cascade do |t|
     t.string "headline"
     t.datetime "effective_date"
@@ -363,9 +353,13 @@ ActiveRecord::Schema.define(version: 2023_04_04_181143) do
     t.index ["service_id"], name: "index_schedules_on_service_id"
   end
 
-  create_table "service_documents", id: false, force: :cascade do |t|
-    t.integer "service_id"
-    t.integer "document_id"
+  create_table "service_at_locations", force: :cascade do |t|
+    t.bigint "service_id"
+    t.bigint "address_id"
+    t.bigint "schedule_id"
+    t.index ["address_id"], name: "index_service_at_locations_on_address_id"
+    t.index ["schedule_id"], name: "index_service_at_locations_on_schedule_id"
+    t.index ["service_id"], name: "index_service_at_locations_on_service_id"
   end
 
   create_table "services", force: :cascade do |t|


### PR DESCRIPTION
Adds URL column to `news_articles` table. Also adds migration to remove defunct `news_article` table. When I ran my migrations locally the `service_at_locations` table showed up in the schema as well. I'm not exactly sure why. Anyone have an idea?