### PR TITLE
Add login page route for auth0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,6 @@ end
 
 gem 'pdfcrowd'
 gem 'google-cloud-translate'
+
+gem 'omniauth-auth0', '~> 3.0'
+gem 'omniauth-rails_csrf_protection', '~> 1.0' # prevents forged authentication requests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
     grpc (1.52.0)
       google-protobuf (~> 3.21)
       googleapis-common-protos-types (~> 1.0)
+    hashie (5.0.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
@@ -191,6 +192,7 @@ GEM
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     multi_json (1.15.0)
+    multi_xml (0.6.0)
     multipart-post (2.3.0)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
@@ -198,6 +200,26 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.1)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-auth0 (3.1.0)
+      omniauth (~> 2)
+      omniauth-oauth2 (~> 1)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     os (1.1.4)
     parallel (1.21.0)
     parser (3.0.2.0)
@@ -213,6 +235,8 @@ GEM
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-protection (3.0.6)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.4.1)
@@ -291,6 +315,9 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     spring (3.0.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -304,6 +331,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
     uniform_notifier (1.14.2)
+    version_gem (1.1.3)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -325,6 +353,8 @@ DEPENDENCIES
   jsonite
   jwt
   lograge
+  omniauth-auth0 (~> 3.0)
+  omniauth-rails_csrf_protection (~> 1.0)
   pdfcrowd
   pg
   phonelib
@@ -341,4 +371,4 @@ DEPENDENCIES
   spring
 
 BUNDLED WITH
-   2.2.15
+   2.3.14

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class AuthController < ApplicationController
+  def authenticate
+    hash = {
+      client_id: Rails.configuration.x.auth0.client_id,
+      response_type: 'code',
+      redirect_uri: auth0_callback_auth_url
+    }
+    redirect_to(URI::HTTPS.build(host: auth0_domain, path: '/authorize', query: hash.to_query).to_s)
+  end
+
+  def callback
+    # OmniAuth stores the information returned from Auth0 and the IdP in request.env['omniauth.auth'].
+    # In this code, you will pull the raw_info supplied from the id_token and assign it to the session.
+    # Refer to
+    # https://github.com/auth0/omniauth-auth0/blob/master/EXAMPLES.md#example-of-the-resulting-authentication-hash
+    # for complete information on 'omniauth.auth' contents.
+    auth_info = request.env['omniauth.auth']
+    session[:userinfo] = auth_info['extra']['raw_info']
+
+    # Redirect to the URL you want after successful auth
+    redirect_to '/api-docs'
+  end
+
+  def failure
+    # Handles failed authentication -- Show a failure page (you can also handle with a redirect)
+    @error_msg = request.params['message']
+  end
+
+  def logout
+    # you will finish this in a later step
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,15 @@ module AskdarcelApi
     # rubocop:enable Layout/LineLength
     config.x.authorization.cert = OpenSSL::X509::Certificate.new(pem)
 
+    # Store for managing cookie-based sessions which are required for OmniAuth
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore, key: 'sheltertech'
+
+    # Auth0 variables
+    config.x.auth0.client_id = ENV['AUTH0_CLIENT_ID']
+    config.x.auth0.client_secret = ENV['AUTH0_CLIENT_SECRET']
+    config.x.auth0.domain = ENV['AUTH0_DOMAIN']
+
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'

--- a/config/initializers/auth0.rb
+++ b/config/initializers/auth0.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider(
+    :auth0,
+    Rails.configuration.x.auth0.client_id,
+    Rails.configuration.x.auth0.client_secret,
+    Rails.configuration.x.auth0.domain,
+    callback_path: '/auth/auth0/callback',
+    authorize_params: {
+      scope: 'openid profile'
+    },
+    provider_ignores_state: true
+  )
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,4 +79,10 @@ Rails.application.routes.draw do
   end
   get 'reindex' => "algolia#reindex"
   post 'translation/translate_text', to: 'translation#translate_text'
+  resource :auth, only: [] do
+    get :auth0, to: 'auth#authenticate', as: :authenticate
+    get :failure
+    get :logout
+    get 'auth0/callback' => 'auth#callback'
+  end
 end


### PR DESCRIPTION
With this change, we can access the login page at /auth/auth0. After login, we are successfully redirected to the callback page which i just set as /api-docs for now.
