### PR TITLE
Enhance texting api

### DIFF
--- a/app/controllers/textings_controller.rb
+++ b/app/controllers/textings_controller.rb
@@ -65,14 +65,14 @@ class TextingsController < ApplicationController
   end
 
   # rubocop:disable Metrics/MethodLength
-  def get_resource_address(resource_address, phone)
-    if resource_address.any?
+  def get_listing_address(address_array, phone)
+    if address_array.any?
       return {
-        address1: resource_address[0].address_1,
-        address2: resource_address[0].address_2,
-        city: resource_address[0].city,
-        state_province: resource_address[0].state_province,
-        postal_code: resource_address[0].postal_code,
+        address1: address_array[0].address_1,
+        address2: address_array[0].address_2,
+        city: address_array[0].city,
+        state_province: address_array[0].state_province,
+        postal_code: address_array[0].postal_code,
         phone: phone
       }
     end
@@ -126,7 +126,7 @@ class TextingsController < ApplicationController
     categories = service.categories.map(&:name)
     resource = Resource.find(service.resource_id)
     phone = get_resource_phone(resource)
-    address = get_resource_address(resource.addresses, phone)
+    address = get_listing_address(service.addresses.any? ? service.addresses : resource.addresses, phone)
 
     generate_data(recipient_name, phone_number, categories, service.name, address)
   end
@@ -135,7 +135,7 @@ class TextingsController < ApplicationController
     resource = Resource.find(resource_id)
     phone = get_resource_phone(resource)
     resource_addresses = resource.addresses
-    address = get_resource_address(resource_addresses, phone)
+    address = get_listing_address(resource_addresses, phone)
     categories = resource.categories.map(&:name)
 
     generate_data(recipient_name, phone_number, categories, resource.name, address)

--- a/app/controllers/textings_controller.rb
+++ b/app/controllers/textings_controller.rb
@@ -7,19 +7,22 @@ class TextingsController < ApplicationController
   def create
     text_data = aggregate_text_data
 
-    # Make a request to Textellent API. If the request is successful, we update our DB
+    # Make a request to Textellent API. If the request is successful, we store a record in our DB
     response = JSON.parse(post_textellent(text_data).body)
     Rails.logger.info(response)
+
     if response['status'] != 'success'
       render status: :bad_request, json: { error: 'failure' }
       return
     end
-    update_db(recipient_name, phone_number)
+    update_db
   end
 
   private
 
-  def update_db(recipient_name, phone_number)
+  def update_db
+    phone_number = texting_params[:phone_number]
+    recipient_name = texting_params[:recipient_name]
     recipient = TextingRecipient.find_by(phone_number: phone_number)
 
     if recipient

--- a/app/controllers/textings_controller.rb
+++ b/app/controllers/textings_controller.rb
@@ -105,7 +105,7 @@ class TextingsController < ApplicationController
         "Zip" => address[:postal_code],
         "Org_Phone" => address[:phone]
       }
-    }
+    }.with_indifferent_access
   end
 
   def aggregate_text_data

--- a/app/controllers/textings_controller.rb
+++ b/app/controllers/textings_controller.rb
@@ -15,14 +15,14 @@ class TextingsController < ApplicationController
       render status: :bad_request, json: { error: 'failure' }
       return
     end
-    update_db
+    update_db(text_data)
   end
 
   private
 
-  def update_db
-    phone_number = texting_params[:phone_number]
-    recipient_name = texting_params[:recipient_name]
+  def update_db(text_data)
+    phone_number = text_data[:mobilePhone]
+    recipient_name = text_data[:firstName]
     recipient = TextingRecipient.find_by(phone_number: phone_number)
 
     if recipient

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -22,6 +22,7 @@ class Resource < ActiveRecord::Base
   has_many :change_requests, dependent: :destroy
   has_many :programs, dependent: :destroy
   has_many :feedbacks, dependent: :destroy
+  has_many :textings
 
   accepts_nested_attributes_for :notes
   accepts_nested_attributes_for :schedule

--- a/app/models/texting.rb
+++ b/app/models/texting.rb
@@ -3,4 +3,5 @@
 class Texting < ApplicationRecord
   belongs_to :texting_recipient
   belongs_to :service
+  belongs_to :resource
 end

--- a/db/migrate/20230718212101_add_resource_refs_to_textings.rb
+++ b/db/migrate/20230718212101_add_resource_refs_to_textings.rb
@@ -1,0 +1,26 @@
+class AddResourceRefsToTextings < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :textings, :resource, index: true, foreign_key: true, null: true
+    change_column_null :textings, :service_id, true
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          ALTER TABLE textings
+          ADD CONSTRAINT resource_xor_service
+          CHECK (
+            (resource_id IS NOT NULL AND service_id IS NULL) OR
+            (resource_id IS NULL AND service_id IS NOT NULL)
+          )
+        SQL
+      end
+
+      dir.down do
+        execute <<-SQL
+          ALTER TABLE textings
+          DROP CONSTRAINT resource_xor_service
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_09_201040) do
+ActiveRecord::Schema.define(version: 2023_07_18_212101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -416,11 +416,14 @@ ActiveRecord::Schema.define(version: 2023_06_09_201040) do
 
   create_table "textings", force: :cascade do |t|
     t.bigint "texting_recipient_id", null: false
-    t.bigint "service_id", null: false
+    t.bigint "service_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "resource_id"
+    t.index ["resource_id"], name: "index_textings_on_resource_id"
     t.index ["service_id"], name: "index_textings_on_service_id"
     t.index ["texting_recipient_id"], name: "index_textings_on_texting_recipient_id"
+    t.check_constraint "((resource_id IS NOT NULL) AND (service_id IS NULL)) OR ((resource_id IS NULL) AND (service_id IS NOT NULL))", name: "resource_xor_service"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
@@ -466,6 +469,7 @@ ActiveRecord::Schema.define(version: 2023_06_09_201040) do
   add_foreign_key "services", "programs"
   add_foreign_key "services", "resources"
   add_foreign_key "synonyms", "synonym_groups"
+  add_foreign_key "textings", "resources"
   add_foreign_key "textings", "services"
   add_foreign_key "textings", "texting_recipients"
   add_foreign_key "volunteers", "resources"


### PR DESCRIPTION
This PR addresses two issues:

1.  It adds support to texting information about resources, which was not previously supported by this API. Resources are listed within our search results and receiving their information may be of interest to our user base; this PR enables this
2. Our texting API was not updated to reflect our support for services that have addresses, which are not inherited from their parent resource's primary address. I've added code that first checks if the selected service has an address and, if not, it falls back to the resource address

There is a corresponding front-end PR [here](https://github.com/ShelterTechSF/askdarcel-web/pull/1281); however, this PR should be able to be merged without breaking the current setup