### PR TITLE
Validate auth0 token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "jwt"
+require "auth0_client"
 
 class ApplicationController < ActionController::API
+  include Secured
+
   rescue_from ActionController::ParameterMissing do
     head :bad_request
   end

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Secured
+  extend ActiveSupport::Concern
+
+  REQUIRES_AUTHENTICATION = { message: 'Requires authentication' }.freeze
+  BAD_CREDENTIALS = {
+    message: 'Bad credentials'
+  }.freeze
+  MALFORMED_AUTHORIZATION_HEADER = {
+    error: 'invalid_request',
+    error_description: 'Authorization header value must follow this format: Bearer access-token',
+    message: 'Bad credentials'
+  }.freeze
+
+  def authorize
+    token = token_from_request
+
+    return if performed?
+
+    validation_response = Auth0Client.validate_token(token)
+
+    return unless (error = validation_response.error)
+
+    render json: { message: error.message }, status: error.status
+  end
+
+  private
+
+  def token_from_request
+    authorization_header_elements = request.headers['Authorization']&.split
+
+    render json: REQUIRES_AUTHENTICATION, status: :unauthorized and return unless authorization_header_elements
+
+    render json: MALFORMED_AUTHORIZATION_HEADER, status: :unauthorized and return unless authorization_header_elements.length == 2
+
+    scheme, token = authorization_header_elements
+
+    render json: BAD_CREDENTIALS, status: :unauthorized and return unless scheme.downcase == 'bearer'
+
+    token
+  end
+end

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -12,6 +12,8 @@ module Secured
   }.freeze
 
   def authorize
+    # This method can be run as a before_action to validate user's token prior to
+    # allowing access to endpoint
     token = token_from_request
 
     return if performed?

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -4,9 +4,7 @@ module Secured
   extend ActiveSupport::Concern
 
   REQUIRES_AUTHENTICATION = { message: 'Requires authentication' }.freeze
-  BAD_CREDENTIALS = {
-    message: 'Bad credentials'
-  }.freeze
+  BAD_CREDENTIALS = { message: 'Bad credentials'}.freeze
   MALFORMED_AUTHORIZATION_HEADER = {
     error: 'invalid_request',
     error_description: 'Authorization header value must follow this format: Bearer access-token',

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# This concern is included in our ApplicationController.
+# It instantiates an Auth0Client, which calls the validate_token method
+# to validate Auth tokens included in requests from the front-end.
 module Secured
   extend ActiveSupport::Concern
 
@@ -11,16 +14,16 @@ module Secured
     message: 'Bad credentials'
   }.freeze
 
+  # The authorize method can be run as a before_action within a controller to validate
+  # a user's token prior to allowing access to an endpoint.
   def authorize
-    # This method can be run as a before_action to validate user's token prior to
-    # allowing access to endpoint
     token = token_from_request
 
     return if performed?
 
     validation_response = Auth0Client.validate_token(token)
-
-    return unless (error = validation_response.error)
+    error = validation_response.error
+    return unless error
 
     render json: { message: error.message }, status: error.status
   end

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -4,7 +4,7 @@ module Secured
   extend ActiveSupport::Concern
 
   REQUIRES_AUTHENTICATION = { message: 'Requires authentication' }.freeze
-  BAD_CREDENTIALS = { message: 'Bad credentials'}.freeze
+  BAD_CREDENTIALS = { message: 'Bad credentials' }.freeze
   MALFORMED_AUTHORIZATION_HEADER = {
     error: 'invalid_request',
     error_description: 'Authorization header value must follow this format: Bearer access-token',

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,7 @@ module AskdarcelApi
     config.x.auth0.client_id = ENV['AUTH0_CLIENT_ID']
     config.x.auth0.client_secret = ENV['AUTH0_CLIENT_SECRET']
     config.x.auth0.domain = ENV['AUTH0_DOMAIN']
+    config.x.auth0.audience = ENV['AUTH0_AUDIENCE']
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do

--- a/lib/auth0_client.rb
+++ b/lib/auth0_client.rb
@@ -47,5 +47,4 @@ class Auth0Client
     Response.new(nil, error)
   end
   # rubocop:enable Lint/ShadowedException
-
 end

--- a/lib/auth0_client.rb
+++ b/lib/auth0_client.rb
@@ -7,11 +7,11 @@ class Auth0Client
   Error = Struct.new(:message, :status)
   Response = Struct.new(:decoded_token, :error)
 
-  def domain_url
+  def self.domain_url
     "https://#{Rails.application.config.x.auth0.domain}/"
   end
 
-  def decode_token(token, jwks_hash)
+  def self.decode_token(token, jwks_hash)
     JWT.decode(token, nil, true, {
                  algorithm: 'RS256',
                  iss: domain_url,
@@ -22,16 +22,16 @@ class Auth0Client
                })
   end
 
-  def jwks
+  def self.jwks
     jwks_uri = URI("#{domain_url}.well-known/jwks.json")
     Net::HTTP.get_response jwks_uri
   end
 
-  def jwks_hash(jwks_response_body)
+  def self.jwks_hash(jwks_response_body)
     JSON.parse(jwks_response_body).deep_symbolize_keys
   end
 
-  def validate_token(token)
+  def self.validate_token(token)
     jwks_response = jwks
 
     unless jwks_response.is_a? Net::HTTPSuccess
@@ -47,4 +47,5 @@ class Auth0Client
     Response.new(nil, error)
   end
   # rubocop:enable Lint/ShadowedException
+
 end

--- a/lib/auth0_client.rb
+++ b/lib/auth0_client.rb
@@ -36,7 +36,7 @@ class Auth0Client
     decoded_token = decode_token(token, jwks_hash)
     Response.new(decoded_token, nil)
   # rubocop:disable Lint/ShadowedException
-  rescue JWT::DecodeError, JWT::VerificationError
+  rescue JWT::DecodeError
     Response.new(nil, Error.new('Bad credentials', :unauthorized))
   end
   # rubocop:enable Lint/ShadowedException

--- a/lib/auth0_client.rb
+++ b/lib/auth0_client.rb
@@ -35,9 +35,7 @@ class Auth0Client
     jwks_hash = JSON.parse(jwks_response.body).deep_symbolize_keys
     decoded_token = decode_token(token, jwks_hash)
     Response.new(decoded_token, nil)
-  # rubocop:disable Lint/ShadowedException
   rescue JWT::DecodeError
     Response.new(nil, Error.new('Bad credentials', :unauthorized))
   end
-  # rubocop:enable Lint/ShadowedException
 end

--- a/lib/auth0_client.rb
+++ b/lib/auth0_client.rb
@@ -4,14 +4,14 @@ require 'jwt'
 require 'net/http'
 
 class Auth0Client
-  AUTH_DOMAIN = URI::HTTPS.build(host: Rails.application.config.x.auth0.domain)
+  Auth_Domain = URI::HTTPS.build(host: Rails.application.config.x.auth0.domain)
   Error = Struct.new(:message, :status)
   Response = Struct.new(:decoded_token, :error)
 
   def self.decode_token(token, jwks_hash)
     JWT.decode(token, nil, true, {
                  algorithm: 'RS256',
-                 iss: URI.join(AUTH_DOMAIN, '/'), # Trailing slash is required to successfully validate token
+                 iss: URI.join(Auth_Domain, '/'), # Trailing slash is required to successfully validate token
                  verify_iss: true,
                  aud: Rails.application.config.x.auth0.audience,
                  verify_aud: true,
@@ -20,7 +20,7 @@ class Auth0Client
   end
 
   def self.fetch_jwks
-    jwks_uri = URI.join(AUTH_DOMAIN, '.well-known/jwks.json')
+    jwks_uri = URI.join(Auth_Domain, '.well-known/jwks.json')
     Net::HTTP.get_response jwks_uri
   end
 

--- a/lib/auth0_client.rb
+++ b/lib/auth0_client.rb
@@ -4,17 +4,14 @@ require 'jwt'
 require 'net/http'
 
 class Auth0Client
+  AUTH_DOMAIN = URI::HTTPS.build(host: Rails.application.config.x.auth0.domain)
   Error = Struct.new(:message, :status)
   Response = Struct.new(:decoded_token, :error)
-
-  def self.domain_url
-    "https://#{Rails.application.config.x.auth0.domain}/"
-  end
 
   def self.decode_token(token, jwks_hash)
     JWT.decode(token, nil, true, {
                  algorithm: 'RS256',
-                 iss: domain_url,
+                 iss: URI.join(AUTH_DOMAIN, '/'), # Trailing slash is required to successfully validate token
                  verify_iss: true,
                  aud: Rails.application.config.x.auth0.audience,
                  verify_aud: true,
@@ -22,29 +19,25 @@ class Auth0Client
                })
   end
 
-  def self.jwks
-    jwks_uri = URI("#{domain_url}.well-known/jwks.json")
+  def self.fetch_jwks
+    jwks_uri = URI.join(AUTH_DOMAIN, '.well-known/jwks.json')
     Net::HTTP.get_response jwks_uri
   end
 
-  def self.jwks_hash(jwks_response_body)
-    JSON.parse(jwks_response_body).deep_symbolize_keys
-  end
-
   def self.validate_token(token)
-    jwks_response = jwks
+    jwks_response = fetch_jwks
 
     unless jwks_response.is_a? Net::HTTPSuccess
       error = Error.new(message: 'Unable to verify credentials', status: :internal_server_error)
       Response.new(nil, error)
     end
 
-    decoded_token = decode_token(token, jwks_hash(jwks_response.body))
+    jwks_hash = JSON.parse(jwks_response.body).deep_symbolize_keys
+    decoded_token = decode_token(token, jwks_hash)
     Response.new(decoded_token, nil)
   # rubocop:disable Lint/ShadowedException
   rescue JWT::DecodeError, JWT::VerificationError
-    error = Error.new('Bad credentials', :unauthorized)
-    Response.new(nil, error)
+    Response.new(nil, Error.new('Bad credentials', :unauthorized))
   end
   # rubocop:enable Lint/ShadowedException
 end

--- a/lib/auth0_client.rb
+++ b/lib/auth0_client.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'jwt'
+require 'net/http'
+
+class Auth0Client
+  Error = Struct.new(:message, :status)
+  Response = Struct.new(:decoded_token, :error)
+
+  def domain_url
+    "https://#{Rails.application.config.x.auth0.domain}/"
+  end
+
+  def decode_token(token, jwks_hash)
+    JWT.decode(token, nil, true, {
+                 algorithm: 'RS256',
+                 iss: domain_url,
+                 verify_iss: true,
+                 aud: Rails.application.config.x.auth0.audience,
+                 verify_aud: true,
+                 jwks: { keys: jwks_hash[:keys] }
+               })
+  end
+
+  def jwks
+    jwks_uri = URI("#{domain_url}.well-known/jwks.json")
+    Net::HTTP.get_response jwks_uri
+  end
+
+  def jwks_hash(jwks_response_body)
+    JSON.parse(jwks_response_body).deep_symbolize_keys
+  end
+
+  def validate_token(token)
+    jwks_response = jwks
+
+    unless jwks_response.is_a? Net::HTTPSuccess
+      error = Error.new(message: 'Unable to verify credentials', status: :internal_server_error)
+      Response.new(nil, error)
+    end
+
+    decoded_token = decode_token(token, jwks_hash(jwks_response.body))
+    Response.new(decoded_token, nil)
+  # rubocop:disable Lint/ShadowedException
+  rescue JWT::DecodeError, JWT::VerificationError
+    error = Error.new('Bad credentials', :unauthorized)
+    Response.new(nil, error)
+  end
+  # rubocop:enable Lint/ShadowedException
+end


### PR DESCRIPTION
I lifted most of this code from Auth0's Rails tutorial [here](https://auth0.com/docs/quickstart/backend/rails/interactive). This can be merged in as is, given it isn't being used yet to lock down any of our endpoints. The Secured#authorize method can be included in any given controller as a `before_action` (with specific controller methods listed out as needed) to restrict access. Let me know if there's any feedback/requests.