### PR TITLE
Add `boosted_category_id` column and add to Algolia index.

### DIFF
--- a/db/migrate/20240804222349_add_boosted_category_to_services.rb
+++ b/db/migrate/20240804222349_add_boosted_category_to_services.rb
@@ -1,0 +1,5 @@
+class AddBoostedCategoryToServices < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :services, :boosted_category, foreign_key: { to_table: :categories }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_02_155441) do
+ActiveRecord::Schema.define(version: 2024_08_04_222349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -418,6 +418,8 @@ ActiveRecord::Schema.define(version: 2024_07_02_155441) do
     t.integer "source_attribution", default: 0
     t.text "internal_note"
     t.string "short_description"
+    t.bigint "boosted_category_id"
+    t.index ["boosted_category_id"], name: "index_services_on_boosted_category_id"
     t.index ["contact_id"], name: "index_services_on_contact_id"
     t.index ["funding_id"], name: "index_services_on_funding_id"
     t.index ["program_id"], name: "index_services_on_program_id"
@@ -521,6 +523,7 @@ ActiveRecord::Schema.define(version: 2024_07_02_155441) do
   add_foreign_key "schedule_days", "schedules"
   add_foreign_key "schedules", "resources"
   add_foreign_key "schedules", "services"
+  add_foreign_key "services", "categories", column: "boosted_category_id"
   add_foreign_key "services", "contacts"
   add_foreign_key "services", "fundings"
   add_foreign_key "services", "programs"


### PR DESCRIPTION
This adds a `boosted_category_id` column to Services, which is a nullable foreign key to the Categories table. This is intended to be used by the frontend code through Algolia as a possible target of the optional filters feature of Algolia, allowing us to boost search rankings for specific services on specific pages.

This column is added to the Algolia index as `boosted_category`, which holds the string name of the category, and we also add it to the `attributesForFaceting` list so that it can be used for optional filters.

Finally, we change the Algolia index ranking order from its default by placing `geo` after `filters`. This is needed in order for optional filters to have higher precedence than geolocation.