### PR TITLE
Add Teen Parent eligibility.

### DIFF
--- a/db/migrate/20240819053931_add_teen_parent_eligibility.rb
+++ b/db/migrate/20240819053931_add_teen_parent_eligibility.rb
@@ -1,0 +1,13 @@
+class AddTeenParentEligibility < ActiveRecord::Migration[6.1]
+  def up
+    exec_query <<-SQL, "create tean parent eligibility", ["Teen Parent"]
+      INSERT INTO eligibilities (name, created_at, updated_at)
+        VALUES ($1, now(), now())
+        ON CONFLICT (name) DO NOTHING;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_04_222349) do
+ActiveRecord::Schema.define(version: 2024_08_19_053931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This creates a data migration that creates the Teen Parent eligibility. Since this is a bit of an urgent request, I'm going to merge this without review and get it deployed to prod, but I've tested that it works for me locally.