### PR TITLE
Fix boosted category facet in Resource model.

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -44,7 +44,7 @@ class Resource < ActiveRecord::Base
                   index_name: "#{Rails.configuration.x.algolia.index_prefix}_services_search",
                   id: :algolia_id do
       # specify the list of attributes available for faceting
-      attributesForFaceting %i[categories open_times eligibilities associated_sites type]
+      attributesForFaceting Rails.configuration.x.algolia.attributes_for_faceting
       # Define attributes used to build an Algolia record
       add_attribute :_geoloc do
         if addresses&.any?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -38,7 +38,7 @@ class Service < ActiveRecord::Base
                   index_name: "#{Rails.configuration.x.algolia.index_prefix}_services_search",
                   id: :algolia_id do
       # specify the list of attributes available for faceting
-      attributesForFaceting %i[categories open_times eligibilities associated_sites type boosted_category]
+      attributesForFaceting Rails.configuration.x.algolia.attributes_for_faceting
 
       # Default has "geo" before "filters", but we need it after if we want
       # optional filters to have higher priority than distance.

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,12 @@ module AskdarcelApi
       config.x.algolia.index_prefix.present?
     ].all?
 
+    # Attributes for faceting (filtering, sorting, etc.) in Algolia. This needs
+    # to be kept in sync between the Service and Resource models, since we're
+    # doing something unusual by having them share the same index, so we define
+    # the list of attributes for faceting as a single constant here.
+    config.x.algolia.attributes_for_faceting = %i[categories open_times eligibilities associated_sites type boosted_category]
+
     config.x.airtable.api_key = ENV['AIRTABLE_API_KEY']
 
     config.x.google.api_key = ENV['GOOGLE_API_KEY']


### PR DESCRIPTION
We recently added a boosted category column on the services table, with the intent of syncing it to Algolia so that we can perform special types of search ranking based on it on the frontend. However, the way we added it resulted in an obscure bug where the feature appeared to work until someone visits the edit page and saves an edit to a resource or service.

The issue is that when we set the `attributesForFaceting` property, we only added the `boosted_category` field to the Service model, not the Resource model. Since we're doing something unusual by sharing the same index for both the Service and Resource model, what actually happens is that the Resource model would sometimes override the `attributesForFaceting` in the Algolia index with its own list, causing that attribute to not be usable in filtering anymore.

This fixes the issue by adding the `boosted_category` field to Resource's list of facets. To prevent this kind of issue from happening in the future, we refactor the list of attributes for faceting into a single constant that both the Service and Resource models share.