### PR TITLE
Rename categories to change Covid- prefix to sfsg-.

### DIFF
--- a/db/migrate/20250226165117_rename_category_covid_prefix_to_sfsg.rb
+++ b/db/migrate/20250226165117_rename_category_covid_prefix_to_sfsg.rb
@@ -1,0 +1,15 @@
+class RenameCategoryCovidPrefixToSfsg < ActiveRecord::Migration[6.1]
+  def up
+    ActiveRecord::Base.transaction do
+      select_all("SELECT id, name FROM categories WHERE name LIKE 'Covid-%'", "get Covid categories").each do |row|
+        old = row["name"]
+        new = row["name"].gsub("Covid-", "sfsg-")
+        exec_query("UPDATE categories SET name = $1 WHERE name = $2", "rename #{old} to #{new}", [new, old])
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_01_30_044205) do
+ActiveRecord::Schema.define(version: 2025_02_26_165117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
These were originally named during the beginning of the COVID-19 pandemic, but since then, they've taken on a more general purpose that is specific to the SFSG site, as opposed to the other white-labeled sites.

Running this migration also needs to be followed up with reindexing the Algolia, and this will also require some coordinated changes on the frontend app.