### PR TITLE
algolia: Bump pagination limit to 4000.

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -45,6 +45,9 @@ class Resource < ActiveRecord::Base
                   id: :algolia_id do
       # specify the list of attributes available for faceting
       attributesForFaceting Rails.configuration.x.algolia.attributes_for_faceting
+
+      paginationLimitedTo 4000
+
       # Define attributes used to build an Algolia record
       add_attribute :_geoloc do
         if addresses&.any?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -40,6 +40,8 @@ class Service < ActiveRecord::Base
       # specify the list of attributes available for faceting
       attributesForFaceting Rails.configuration.x.algolia.attributes_for_faceting
 
+      paginationLimitedTo 4000
+
       # Default has "geo" before "filters", but we need it after if we want
       # optional filters to have higher priority than distance.
       ranking %w[typo words filters geo proximity attribute exact custom]


### PR DESCRIPTION
For the Our415 collaboration, in one of their pages, they would like to have more than 1000 search results, which is above the default limit that Algolia sets. Algolia allows this to be increased, though mentions that there are performance tradeoffs involved, where bumping the number by a lot could slow down search results.

It seems that they are looking at having up to mid 3000s, so we've agreed that 4000 is a reasonable limit to set.

This can be configured via the `algoliasearch-rails` gem, with the `paginationLimitedTo` property that can be set on a index. When a resource or service gets indexed, this causes the setting to be synchrorized to Algolia. The setting is also configurable via the web admin site, but we choose to configure it in the code to ensure that there is a revision controlled source of truth to these settings.

Note that this needs to be configured on both the Resource and Service models, since we do something unusual by having both models share the same Algolia index. Not updating both could result in the setting being changed as the different models are indexed.

I tested this locally by checking that when I manually index one service in my local DB, that when it communicates with Algolia, it causes the index setting to change from 1000 to 4000.