### PR TITLE
ci: fix publish-release workflow indentation and switch to GCP_ARTIFA…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .ruby-version
 .bundle
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: testsuite
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, migrate-to-gcp ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, migrate-to-gcp ]
 
 env:
   RUBY_VERSION: 2.7.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: testsuite
 
 on:
   push:
-    branches: [ master, migrate-to-gcp ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, migrate-to-gcp ]
+    branches: [ master ]
 
 env:
   RUBY_VERSION: 2.7.4
@@ -67,7 +67,7 @@ jobs:
   publish-latest:
     runs-on: ubuntu-latest
     needs: [lint, test_unit, test_postman]
-    if: github.ref == 'refs/heads/migrate-to-gcp' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
   publish-latest:
     runs-on: ubuntu-latest
     needs: [lint, test_unit, test_postman]
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/migrate-to-gcp' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ env:
   NODE_VERSION: 16.x
   RAILS_ENV: test
   TEXTELLENT_AUTH_CODE: ${{ secrets.TEXTELLENT_AUTH_CODE }}
+  GCP_REPO: us-west2-docker.pkg.dev/askdarcel-184805/sheltertech/askdarcel-api
   DOCKER_REPO: sheltertechsf/askdarcel-api
 
 jobs:
@@ -71,6 +72,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_KEY }}
+      - uses: docker/login-action@v3
+        with:
+          registry: us-west2-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_ARTIFACT_REGISTRY_KEY }}
       - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -78,5 +87,7 @@ jobs:
       - uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ env.DOCKER_REPO }}:latest
+          tags: |
+            ${{ env.DOCKER_REPO }}:latest
+            ${{ env.GCP_REPO }}:latest
       - run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,21 +31,20 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: google-github-actions/auth@v2
+        # Login to google registry
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      # Login to google registry
+          credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_KEY }}
+        # Authenticate with Google Cloud
       - uses: docker/login-action@v3
         with:
           registry: us-west2-docker.pkg.dev
           username: _json_key
-          password: ${{ secrets.GCP_SA_KEY }}
-
-
+          password: ${{ secrets.GCP_ARTIFACT_REGISTRY_KEY }}
       - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      # Authenticate with Google Cloud
+        # Build and push to both registries
       - uses: docker/build-push-action@v2
         with:
           push: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,7 @@ on:
       - '*'
 
 env:
+  GCP_REPO: us-west2-docker.pkg.dev/askdarcel-184805/sheltertech/askdarcel-api
   DOCKER_REPO: sheltertechsf/askdarcel-api
 
 jobs:
@@ -23,15 +24,28 @@ jobs:
             prefix=
             suffix=
           images: |
+            ${{ env.GCP_REPO }}
             ${{ env.DOCKER_REPO }}
           tags: |
             type=semver,pattern={{version}}
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+      # Login to google registry
+      - uses: docker/login-action@v3
+        with:
+          registry: us-west2-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_SA_KEY }}
+
+
       - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      # Authenticate with Google Cloud
       - uses: docker/build-push-action@v2
         with:
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,38 @@ FROM sheltertechsf/combostrikehq-docker-rails:ruby-2.7
 # NB The xenial-pgdg package that we're installing with APT below may be removed from Postgres' repo
 # when future Linux updates come out. See: https://wiki.postgresql.org/wiki/Apt for updates.
 
+# Restore dpkg directories and status file
 RUN mkdir -p /var/lib/dpkg/alternatives /var/lib/dpkg/info /var/lib/dpkg/parts /var/lib/dpkg/triggers /var/lib/dpkg/updates && \
-  touch /var/lib/dpkg/status && \
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-  mv /home/app/webapp/config/appserver.sh /etc/service/appserver/run && \
-  chmod 777 /etc/service/appserver/run && \
-  echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
-  curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-  apt-get update && \
-  apt-get install -y libglib2.0-dev && \
-  apt-get install -y postgresql-client-common && \
+  touch /var/lib/dpkg/status
+
+# Install prerequisites for GPG keyring management
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends curl wget gnupg ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
-ENV LD_PRELOAD=$LD_PRELOAD:/lib/x86_64-linux-gnu/libjemalloc.so.2
+# Create keyrings directory
+RUN mkdir -p /usr/share/keyrings
+
+# Add Yarn repository with modern GPG keyring approach
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/yarn-keyring.gpg && \
+  echo "deb [signed-by=/usr/share/keyrings/yarn-keyring.gpg] https://dl.yarnpkg.com/debian stable main" > /etc/apt/sources.list.d/yarn.list
+
+# Add Google Chrome repository with modern GPG keyring approach
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome-keyring.gpg && \
+  echo "deb [signed-by=/usr/share/keyrings/google-chrome-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+
+# Add PostgreSQL repository with modern GPG keyring approach
+RUN curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg && \
+  echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+
+# Install required packages
+RUN apt-get update && \
+  apt-get install -y libglib2.0-dev postgresql-client-common && \
+  rm -rf /var/lib/apt/lists/*
+
+# Configure appserver
+RUN mkdir -p /etc/service/appserver && \
+  mv /home/app/webapp/config/appserver.sh /etc/service/appserver/run && \
+  chmod 777 /etc/service/appserver/run
+
+ENV LD_PRELOAD=${LD_PRELOAD}:/lib/x86_64-linux-gnu/libjemalloc.so.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,19 +11,15 @@ FROM sheltertechsf/combostrikehq-docker-rails:ruby-2.7
 
 RUN mkdir -p /var/lib/dpkg/alternatives /var/lib/dpkg/info /var/lib/dpkg/parts /var/lib/dpkg/triggers /var/lib/dpkg/updates && \
   touch /var/lib/dpkg/status && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends curl wget gnupg ca-certificates && \
-  install -m 0755 -d /etc/apt/keyrings && \
-  curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn.gpg && \
-  wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/google.gpg && \
-  echo 'deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list && \
-  mkdir -p /etc/service/appserver && \
+  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   mv /home/app/webapp/config/appserver.sh /etc/service/appserver/run && \
   chmod 777 /etc/service/appserver/run && \
-  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/postgres.gpg && \
-  echo 'deb [signed-by=/etc/apt/keyrings/postgres.gpg] http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
+  echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
+  curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
   apt-get update && \
-  apt-get install -y libglib2.0-dev postgresql-client-common && \
+  apt-get install -y libglib2.0-dev && \
+  apt-get install -y postgresql-client-common && \
   rm -rf /var/lib/apt/lists/*
 
 ENV LD_PRELOAD=$LD_PRELOAD:/lib/x86_64-linux-gnu/libjemalloc.so.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,9 @@ RUN apt-get clean && \
 RUN mkdir -p /usr/share/keyrings
 
 # Add PostgreSQL repository with modern GPG keyring approach for postgresql-client-common
-# Download and verify GPG key
-RUN curl --silent --fail --location https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /tmp/postgresql.asc && \
-  gpg --dearmor /tmp/postgresql.asc -o /usr/share/keyrings/postgresql-keyring.gpg && \
-  rm /tmp/postgresql.asc && \
+# Download and process GPG key using wget (more reliable for piping)
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+  gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg && \
   test -f /usr/share/keyrings/postgresql-keyring.gpg
 
 # Add PostgreSQL repository configuration
@@ -55,4 +54,4 @@ RUN mkdir -p /etc/service/appserver && \
   mv /home/app/webapp/config/appserver.sh /etc/service/appserver/run && \
   chmod 777 /etc/service/appserver/run
 
-ENV LD_PRELOAD=${LD_PRELOAD:-}:/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=/lib/x86_64-linux-gnu/libjemalloc.so.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,19 @@ FROM sheltertechsf/combostrikehq-docker-rails:ruby-2.7
 
 RUN mkdir -p /var/lib/dpkg/alternatives /var/lib/dpkg/info /var/lib/dpkg/parts /var/lib/dpkg/triggers /var/lib/dpkg/updates && \
   touch /var/lib/dpkg/status && \
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends curl wget gnupg ca-certificates && \
+  install -m 0755 -d /etc/apt/keyrings && \
+  curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn.gpg && \
+  wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/google.gpg && \
+  echo 'deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list && \
   mkdir -p /etc/service/appserver && \
   mv /home/app/webapp/config/appserver.sh /etc/service/appserver/run && \
   chmod 777 /etc/service/appserver/run && \
-  echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
-  curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/postgres.gpg && \
+  echo 'deb [signed-by=/etc/apt/keyrings/postgres.gpg] http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
   apt-get update && \
-  apt-get install -y libglib2.0-dev && \
-  apt-get install -y postgresql-client-common && \
+  apt-get install -y libglib2.0-dev postgresql-client-common && \
   rm -rf /var/lib/apt/lists/*
 
 ENV LD_PRELOAD=$LD_PRELOAD:/lib/x86_64-linux-gnu/libjemalloc.so.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,23 +22,22 @@ RUN apt-get update --allow-releaseinfo-change && \
   apt-get install -y --no-install-recommends curl wget gnupg ca-certificates apt-transport-https && \
   rm -rf /var/lib/apt/lists/*
 
+# Install libglib2.0-dev from default Ubuntu repositories first
+RUN apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  apt-get update --allow-releaseinfo-change && \
+  apt-get install -y libglib2.0-dev && \
+  rm -rf /var/lib/apt/lists/*
+
 # Create keyrings directory
 RUN mkdir -p /usr/share/keyrings
 
-# Add PostgreSQL repository with modern GPG keyring approach
+# Add PostgreSQL repository with modern GPG keyring approach for postgresql-client-common
 # Use HTTPS and ensure proper keyring setup
-# Only add PostgreSQL repo as that's what we need for postgresql-client-common
 RUN curl --silent --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg && \
-  echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-
-# Clean apt cache and update package lists
-# --allow-releaseinfo-change handles repository metadata changes
-RUN apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
-  apt-get update --allow-releaseinfo-change
-
-# Install required packages
-RUN apt-get install -y libglib2.0-dev postgresql-client-common && \
+  echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+  apt-get update --allow-releaseinfo-change && \
+  apt-get install -y postgresql-client-common && \
   rm -rf /var/lib/apt/lists/*
 
 # Configure appserver
@@ -46,4 +45,4 @@ RUN mkdir -p /etc/service/appserver && \
   mv /home/app/webapp/config/appserver.sh /etc/service/appserver/run && \
   chmod 777 /etc/service/appserver/run
 
-ENV LD_PRELOAD=${LD_PRELOAD}:/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=${LD_PRELOAD:-}:/lib/x86_64-linux-gnu/libjemalloc.so.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,21 +39,12 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
   test -f /usr/share/keyrings/postgresql-keyring.gpg
 
 # Add PostgreSQL repository configuration
-RUN echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-  cat /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 # Update package lists and install postgresql-client-common
-# Capture error output for debugging
 RUN apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  apt-get update --allow-releaseinfo-change 2>&1 | tee /tmp/apt-update.log || \
-  (echo "=== apt-get update failed ===" && \
-   cat /tmp/apt-update.log && \
-   echo "=== Checking repository config ===" && \
-   cat /etc/apt/sources.list.d/pgdg.list && \
-   echo "=== Checking keyring file ===" && \
-   ls -la /usr/share/keyrings/postgresql-keyring.gpg && \
-   exit 1) && \
+  apt-get update --allow-releaseinfo-change && \
   apt-get install -y postgresql-client-common && \
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,26 +31,14 @@ RUN mkdir -p /usr/share/keyrings
 RUN curl --silent --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg && \
   echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
-# List all repository configurations for debugging
-RUN echo "=== Checking repository configurations ===" && \
-  ls -la /etc/apt/sources.list.d/ 2>/dev/null || true && \
-  cat /etc/apt/sources.list 2>/dev/null || true
-
 # Clean apt cache and update package lists
 # --allow-releaseinfo-change handles repository metadata changes
 RUN apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  apt-get update --allow-releaseinfo-change 2>&1 | tee /tmp/apt-update.log || \
-  (echo "=== apt-get update failed, checking logs ===" && \
-   cat /tmp/apt-update.log && \
-   echo "=== Listing problematic repos ===" && \
-   grep -r "Err\|W:" /tmp/apt-update.log || true && \
-   exit 1)
+  apt-get update --allow-releaseinfo-change
 
 # Install required packages
-# Install each package separately to identify which one fails
-RUN apt-get install -y libglib2.0-dev && \
-  apt-get install -y postgresql-client-common && \
+RUN apt-get install -y libglib2.0-dev postgresql-client-common && \
   rm -rf /var/lib/apt/lists/*
 
 # Configure appserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,12 +42,19 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
 RUN echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 # Update package lists and install postgresql-client-common
-# Add retry logic for network/repository issues
+# Debug: Show error details if update fails
 RUN apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  (apt-get update --allow-releaseinfo-change || \
-   (sleep 2 && apt-get update --allow-releaseinfo-change) || \
-   (sleep 5 && apt-get update --allow-releaseinfo-change)) && \
+  apt-get update --allow-releaseinfo-change 2>&1 | tee /tmp/apt-update.log || \
+  (echo "=== apt-get update failed, showing error details ===" && \
+   cat /tmp/apt-update.log | grep -E "Err|W:|E:" | head -20 && \
+   echo "=== Repository configuration ===" && \
+   cat /etc/apt/sources.list.d/pgdg.list && \
+   echo "=== Keyring file check ===" && \
+   ls -la /usr/share/keyrings/postgresql-keyring.gpg && \
+   echo "=== All sources.list.d files ===" && \
+   ls -la /etc/apt/sources.list.d/ && \
+   exit 1) && \
   apt-get install -y postgresql-client-common && \
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,17 @@ RUN echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt
   cat /etc/apt/sources.list.d/pgdg.list
 
 # Update package lists and install postgresql-client-common
+# Capture error output for debugging
 RUN apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  apt-get update --allow-releaseinfo-change && \
+  apt-get update --allow-releaseinfo-change 2>&1 | tee /tmp/apt-update.log || \
+  (echo "=== apt-get update failed ===" && \
+   cat /tmp/apt-update.log && \
+   echo "=== Checking repository config ===" && \
+   cat /etc/apt/sources.list.d/pgdg.list && \
+   echo "=== Checking keyring file ===" && \
+   ls -la /usr/share/keyrings/postgresql-keyring.gpg && \
+   exit 1) && \
   apt-get install -y postgresql-client-common && \
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN mkdir -p /var/lib/dpkg/alternatives /var/lib/dpkg/info /var/lib/dpkg/parts /
   touch /var/lib/dpkg/status && \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  mkdir -p /etc/service/appserver && \
   mv /home/app/webapp/config/appserver.sh /etc/service/appserver/run && \
   chmod 777 /etc/service/appserver/run && \
   echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,12 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
 RUN echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 # Update package lists and install postgresql-client-common
+# Add retry logic for network/repository issues
 RUN apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  apt-get update --allow-releaseinfo-change && \
+  (apt-get update --allow-releaseinfo-change || \
+   (sleep 2 && apt-get update --allow-releaseinfo-change) || \
+   (sleep 5 && apt-get update --allow-releaseinfo-change)) && \
   apt-get install -y postgresql-client-common && \
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,12 @@ FROM sheltertechsf/combostrikehq-docker-rails:ruby-2.7
 RUN mkdir -p /var/lib/dpkg/alternatives /var/lib/dpkg/info /var/lib/dpkg/parts /var/lib/dpkg/triggers /var/lib/dpkg/updates && \
   touch /var/lib/dpkg/status
 
+# Remove problematic repository configurations that may have expired/missing GPG keys
+# These will be re-added with proper keys later
+RUN rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/google-chrome.list 2>/dev/null || true
+
 # Install prerequisites for GPG keyring management
-RUN apt-get update && \
+RUN apt-get update --allow-releaseinfo-change && \
   apt-get install -y --no-install-recommends curl wget gnupg ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
…CT_REGISTRY_KEY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes images to both Docker Hub and Google Artifact Registry in CI and release workflows.
> 
> - Adds `GCP_REPO` and configures `google-github-actions/auth` + `docker/login-action` for `us-west2-docker.pkg.dev`
> - Updates `ci.yml` `publish-latest` to tag/push `${DOCKER_REPO}:latest` and `${GCP_REPO}:latest`
> - Updates `publish-release.yml` to generate tags for both `${GCP_REPO}` and `${DOCKER_REPO}` and push to both registries
> - Adds `.dockerignore` rule to exclude `gha-creds-*.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fad8666272a882d610e65cf8a6098ee73c7e9fb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->