### PR TITLE
Fix import staging script

### DIFF
--- a/lib/sheltertech/db/staging_importer.rb
+++ b/lib/sheltertech/db/staging_importer.rb
@@ -201,14 +201,17 @@ module ShelterTech
       # queries.
       def self.fast_insert!(table_name, record)
         keys = record.keys
+        conn = ActiveRecord::Base.connection
         values = keys.map { |k| record[k] }
-        question_marks = Array.new(values.size) { '?' }
+        quoted_table = conn.quote_table_name(table_name)
+        quoted_keys  = keys.map { |k| conn.quote_column_name(k) }
+        question_marks = Array.new(values.size, '?')
         sql_query = [
-          "INSERT INTO #{table_name} (#{keys.join(', ')}) VALUES (#{question_marks.join(', ')})"
+          "INSERT INTO #{quoted_table} (#{quoted_keys.join(', ')}) VALUES (#{question_marks.join(', ')})"
         ]
         sql_query += values
         sql_query = ActiveRecord::Base.send(:sanitize_sql_array, sql_query)
-        ActiveRecord::Base.connection.execute(sql_query)
+        conn.execute(sql_query)
       end
 
       def self.log_progress(msg)

--- a/lib/sheltertech/db/staging_importer.rb
+++ b/lib/sheltertech/db/staging_importer.rb
@@ -206,9 +206,7 @@ module ShelterTech
         quoted_table = conn.quote_table_name(table_name)
         quoted_keys  = keys.map { |k| conn.quote_column_name(k) }
         question_marks = Array.new(values.size, '?')
-        sql_query = [
-          "INSERT INTO #{quoted_table} (#{quoted_keys.join(', ')}) VALUES (#{question_marks.join(', ')})"
-        ]
+        sql_query = ["INSERT INTO #{quoted_table} (#{quoted_keys.join(', ')}) VALUES (#{question_marks.join(', ')})"]
         sql_query += values
         sql_query = ActiveRecord::Base.send(:sanitize_sql_array, sql_query)
         conn.execute(sql_query)


### PR DESCRIPTION
The import staging script was choking on the bookmarks table due to it having a column named "order", which is a reserved keyword in pgsql. This PR enhances our staging_importer#fast_insert method by quoting table name and column name and thus preventing this from happening with other reserved words.